### PR TITLE
Gro16 verifier gadget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,12 @@ option(
   ON
 )
 
+option(
+  USE_ASAN
+  "Enable Address Sanitizer"
+  OFF
+)
+
 set(
   OPT_FLAGS
   ""
@@ -218,6 +224,13 @@ endif()
 
 if("${USE_ASM}")
   add_definitions(-DUSE_ASM)
+endif()
+
+if("${USE_ASAN}")
+  set(
+    CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -fsanitize=address"
+  )
 endif()
 
 if("${USE_LINKED_LIBRARIES}")

--- a/libsnark/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
@@ -24,6 +24,7 @@
 #include <libsnark/gadgetlib1/gadgets/fields/fp4_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/fields/fp6_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.hpp>
 
 namespace libsnark {
 
@@ -61,6 +62,7 @@ public:
 
     typedef libff::mnt6_pp other_curve_type;
 
+    typedef mnt_miller_loop_gadget<libff::mnt4_pp> miller_loop_gadget;
     typedef mnt_e_over_e_miller_loop_gadget<libff::mnt4_pp> e_over_e_miller_loop_gadget_type;
     typedef mnt_e_times_e_over_e_miller_loop_gadget<libff::mnt4_pp> e_times_e_over_e_miller_loop_gadget_type;
     typedef mnt4_final_exp_gadget<libff::mnt4_pp> final_exp_gadget_type;
@@ -91,6 +93,7 @@ public:
 
     typedef libff::mnt4_pp other_curve_type;
 
+    typedef mnt_miller_loop_gadget<libff::mnt6_pp> miller_loop_gadget;
     typedef mnt_e_over_e_miller_loop_gadget<libff::mnt6_pp> e_over_e_miller_loop_gadget_type;
     typedef mnt_e_times_e_over_e_miller_loop_gadget<libff::mnt6_pp> e_times_e_over_e_miller_loop_gadget_type;
     typedef mnt6_final_exp_gadget<libff::mnt6_pp> final_exp_gadget_type;

--- a/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp
@@ -119,7 +119,6 @@ public:
 
     std::vector<Fqk_variable<ppT> > m_miller_results;
     std::vector<miller_loop_gadget<ppT> > m_miller_loops;
-    std::vector<Fqk_variable<ppT>> m_precomputed_loops;
     std::vector<Fqk_variable<ppT> > m_product_results;
     std::vector<Fqk_mul_gadget<ppT> > m_product;
     std::shared_ptr<final_exp_gadget<ppT> > m_final_exp;

--- a/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp
@@ -119,6 +119,7 @@ public:
 
     std::vector<Fqk_variable<ppT> > m_miller_results;
     std::vector<miller_loop_gadget<ppT> > m_miller_loops;
+    std::vector<Fqk_variable<ppT>> m_precomputed_loops;
     std::vector<Fqk_variable<ppT> > m_product_results;
     std::vector<Fqk_mul_gadget<ppT> > m_product;
     std::shared_ptr<final_exp_gadget<ppT> > m_final_exp;
@@ -126,6 +127,11 @@ public:
 
     pairing_product_gadget(protoboard<FieldT> &pb,
                            const std::vector<pairing_input_pair<ppT>> &pairs,
+                           const std::string &annotation_prefix);
+
+    pairing_product_gadget(protoboard<FieldT> &pb,
+                           const std::vector<pairing_input_pair<ppT>> &pairs,
+                           const std::vector<Fqk_variable<ppT>> &precomputed_loops,
                            const std::string &annotation_prefix);
 
     void generate_r1cs_constraints();

--- a/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.tcc
+++ b/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.tcc
@@ -14,6 +14,7 @@
 #ifndef PAIRING_CHECKS_TCC_
 #define PAIRING_CHECKS_TCC_
 
+
 namespace libsnark {
 
 template<typename ppT>
@@ -87,6 +88,116 @@ void check_e_equals_ee_gadget<ppT>::generate_r1cs_witness()
     compute_ratio->generate_r1cs_witness();
     check_finexp->generate_r1cs_witness();
 }
+
+
+
+template<typename ppT>
+pairing_product_gadget<ppT>::pairing_product_gadget(
+    protoboard<FieldT> &pb,
+    const std::vector<pairing_input_pair<ppT>> &pairs,
+    const std::string &annotation_prefix
+) :
+    gadget<FieldT>(pb, annotation_prefix)
+{
+    assert( pairs.size() > 0 );
+    result_is_one.allocate(pb, FMT(annotation_prefix, ".result_is_one"));
+
+    // XXX: must be reserved, otherwise emplace_back will call destructor on miller loop during move which invalidates shared_ptr
+    m_miller_results.reserve(pairs.size());
+    m_miller_loops.reserve(pairs.size());
+    if( pairs.size() > 1 ) {
+        m_product_results.reserve(pairs.size() - 1);
+        m_product.reserve(pairs.size() - 1);
+    }
+
+    int i = 0;
+    for( const auto &p_ref : pairs )
+    {
+        m_miller_results.emplace_back(pb, FMT(annotation_prefix, ".result_%d", i));
+        m_miller_loops.emplace_back(
+            pb,
+            p_ref.g1,
+            p_ref.g2,
+            m_miller_results[i],
+            FMT(annotation_prefix, ".miller_loop_%d", i));
+
+        if( i > 0 )
+        {
+            m_product_results.emplace_back(pb, FMT(annotation_prefix, ".product_result_%d", i));
+
+            if( m_product_results.size() == 1 )
+            {
+                assert( m_miller_results.size() == 2 );
+                // pr[0] = result[0] * result[1]
+                m_product.emplace_back(
+                    pb,
+                    m_miller_results[0],
+                    m_miller_results.back(),
+                    m_product_results.back(),
+                    FMT(annotation_prefix, ".product_%d", i));
+            }
+            else {
+                // pr[i] = pr[i-1] * result[i]
+                m_product.emplace_back(
+                    pb,
+                    m_product_results[ m_product_results.size() - 2 ] ,  // Previous product
+                    m_miller_results.back(),
+                    m_product_results.back(),
+                    FMT(annotation_prefix, ".product_%d", i));
+            }
+        }
+
+        i += 1;
+    }
+
+    m_final_exp.reset(new final_exp_gadget<ppT>(pb, raw_result(), result_is_one, FMT(annotation_prefix, ".check_is_one")));
+}
+
+
+template<typename ppT>
+void pairing_product_gadget<ppT>::generate_r1cs_constraints()
+{
+    for( auto &m : m_miller_loops )
+        m.generate_r1cs_constraints();
+
+    for( auto &p : m_product )
+        p.generate_r1cs_constraints();
+
+    m_final_exp->generate_r1cs_constraints();
+}
+
+
+template<typename ppT>
+void pairing_product_gadget<ppT>::generate_r1cs_witness()
+{
+    for( auto &m : m_miller_loops )
+        m.generate_r1cs_witness();
+
+    for( auto &p : m_product )
+        p.generate_r1cs_witness();
+
+    m_final_exp->generate_r1cs_witness();
+}
+
+
+template<typename ppT>
+Fqk_variable<ppT>& pairing_product_gadget<ppT>::result()
+{
+    return *m_final_exp->result;
+}
+
+
+template<typename ppT>
+Fqk_variable<ppT>& pairing_product_gadget<ppT>::raw_result()
+{
+    if( m_product_results.size() > 0 ) {
+        return m_product_results.back();
+    }
+
+    // When there is only one pairing, and no product...
+    return m_miller_results.back();
+}
+
 
 } // libsnark
 

--- a/libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp
@@ -105,6 +105,9 @@ template<typename ppT>
 using other_curve = typename pairing_selector<ppT>::other_curve_type;
 
 template<typename ppT>
+using miller_loop_gadget = typename pairing_selector<ppT>::miller_loop_gadget;
+
+template<typename ppT>
 using e_over_e_miller_loop_gadget = typename pairing_selector<ppT>::e_over_e_miller_loop_gadget_type;
 template<typename ppT>
 using e_times_e_over_e_miller_loop_gadget = typename pairing_selector<ppT>::e_times_e_over_e_miller_loop_gadget_type;

--- a/libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp
@@ -1,0 +1,460 @@
+#pragma once
+
+#include <libsnark/gadgetlib1/gadgets/basic_gadgets.hpp>
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp>
+
+namespace libsnark {
+
+
+/**
+* Holds a Groth16 proof with its inputs
+* The A, B and C points are validated
+*/
+template<typename ppT>
+class gro16_proof_var : public gadget<libff::Fr<ppT> > {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+    typedef pb_variable<FieldT> FieldVarT;
+
+    G1VarT A;
+    G2VarT B;
+    G1VarT C;
+
+    // XXX: do we need a mode where we don't validate the proof points?
+    G1_checker_gadget<ppT> m_A_checker;
+    G2_checker_gadget<ppT> m_B_checker;
+    G1_checker_gadget<ppT> m_C_checker;
+
+    gro16_proof_var(
+        protoboard<FieldT> &pb,
+        const G1VarT &_A,
+        const G2VarT &_B,
+        const G1VarT &_C,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        A(_A),
+        B(_B),
+        C(_C),
+        m_A_checker(pb, A, FMT(annotation_prefix, ".A_checker")),
+        m_B_checker(pb, B, FMT(annotation_prefix, ".B_checker")),
+        m_C_checker(pb, C, FMT(annotation_prefix, ".C_checker"))
+    { }
+
+    gro16_proof_var(
+        protoboard<FieldT> &pb,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        A(pb, FMT(this->annotation_prefix, ".A")),
+        B(pb, FMT(this->annotation_prefix, ".B")),
+        C(pb, FMT(this->annotation_prefix, ".C")),
+        m_A_checker(pb, A, FMT(annotation_prefix, ".A_checker")),
+        m_B_checker(pb, B, FMT(annotation_prefix, ".B_checker")),
+        m_C_checker(pb, C, FMT(annotation_prefix, ".C_checker"))
+    {
+
+    }
+
+    void generate_r1cs_constraints()
+    {
+        m_A_checker.generate_r1cs_constraints();
+        m_B_checker.generate_r1cs_constraints();
+        m_C_checker.generate_r1cs_constraints();
+    }
+
+    /** Variables are already filled with values */
+    void generate_r1cs_witness()
+    {
+        m_A_checker.generate_r1cs_witness();
+        m_B_checker.generate_r1cs_witness();
+        m_C_checker.generate_r1cs_witness();
+    }
+
+    /** Fill variables from proof with inputs */
+    void generate_r1cs_witness(
+        const r1cs_gg_ppzksnark_proof<other_curve<ppT>> &proof
+    ) {
+        A.generate_r1cs_witness(proof.g_A);
+        B.generate_r1cs_witness(proof.g_B);
+        C.generate_r1cs_witness(proof.g_C);
+        generate_r1cs_witness();
+    }
+};
+
+
+/**
+* Holds a Groth16 verification key as variables
+* The points of the verification key are validated
+* This will be given to the preprocessor gadget
+*/
+template<typename ppT>
+class gro16_vk_var : public gadget<libff::Fr<ppT> > {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+
+    G1VarT m_alpha;
+    G2VarT m_beta;
+    G2VarT m_gamma;
+    G2VarT m_delta;
+
+    size_t n_inputs;
+    std::vector<G1VarT> m_IC;
+
+    std::vector<G1_checker_gadget<ppT>> m_g1_checkers;
+    std::vector<G2_checker_gadget<ppT>> m_g2_checkers;
+
+    void _init_checkers()
+    {
+        auto pb = this->pb;
+        const auto annotation_prefix = this->annotation_prefix;
+
+        m_g1_checkers.reserve(n_inputs + 1);
+        m_g1_checkers.emplace_back(pb, m_alpha, FMT(annotation_prefix, ".alpha_checker"));
+
+        m_g2_checkers.reserve(3);
+        m_g2_checkers.emplace_back(pb, m_beta, FMT(annotation_prefix, ".beta_checker"));
+        m_g2_checkers.emplace_back(pb, m_gamma, FMT(annotation_prefix, ".gamma_checker"));
+        m_g2_checkers.emplace_back(pb, m_delta, FMT(annotation_prefix, ".delta_checker"));
+
+        assert( n_inputs > 0 );
+        for( size_t i = 0; i < (n_inputs + 1); i++ )
+        {
+            m_IC.emplace_back(pb, FMT(annotation_prefix, ".input_%d", i));
+            m_g1_checkers.emplace_back(pb, m_IC.back(), FMT(annotation_prefix, ".IC_checker_%d", i));
+        }
+    }
+
+    /**
+    * Construct new variables to hold the verification key
+    * For when the verification key is a secret input
+    */
+    gro16_vk_var(
+        protoboard<FieldT> &pb,
+        size_t _n_inputs,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        m_alpha(pb, FMT(annotation_prefix, ".alpha")),
+        m_beta(pb, FMT(annotation_prefix, ".beta")),
+        m_gamma(pb, FMT(annotation_prefix, ".gamma")),
+        m_delta(pb, FMT(annotation_prefix, ".delta")),
+        n_inputs(_n_inputs)
+    {
+        _init_checkers();
+    }
+
+    /**
+    * Fill verification key from already existing variables
+    * When the verification key comes from somewhere else within the circuit
+    */
+    gro16_vk_var(
+        protoboard<FieldT> &pb,
+        const G1VarT &alpha,
+        const G2VarT &beta,
+        const G2VarT &gamma,
+        const G2VarT &delta,
+        const std::vector<G1VarT> &IC,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        m_alpha(alpha),
+        m_beta(beta),
+        m_gamma(gamma),
+        m_delta(delta),
+        n_inputs(IC.size())
+    {
+        _init_checkers();
+    }
+
+    void generate_r1cs_constraints()
+    {
+        for( auto &gadget : m_g1_checkers )
+            gadget.generate_r1cs_constraints();
+
+        for( auto &gadget : m_g2_checkers )
+            gadget.generate_r1cs_constraints();
+    }
+
+    /** When the VK variable values have already been filled */
+    void generate_r1cs_witness()
+    {
+        for( auto &gadget : m_g1_checkers )
+            gadget.generate_r1cs_constraints();
+
+        for( auto &gadget : m_g2_checkers )
+            gadget.generate_r1cs_constraints();
+    }
+
+    /** Fill variable values before witness of point checkers */
+    void generate_r1cs_witness(
+        const libff::G1<ppT> &alpha,
+        const libff::G2<ppT> &beta,
+        const libff::G2<ppT> &gamma,
+        const libff::G2<ppT> &delta,
+        const std::vector<libff::G1<ppT>> &IC
+    ) {
+        m_alpha.generate_r1cs_witness(alpha);
+        m_beta.generate_r1cs_witness(beta);
+        m_gamma.generate_r1cs_witness(gamma);
+        m_delta.generate_r1cs_witness(delta);
+
+        assert( m_IC.size() == IC.size() );
+        int i = 0;
+        for( const auto& x: IC )
+            m_IC[i++].generate_r1cs_witness(x);
+
+        generate_r1cs_witness();
+    }
+
+    template<typename T>
+    void generate_r1cs_witness(
+        const libsnark::r1cs_gg_ppzksnark_verification_key<T> &vk
+    ) {
+        m_alpha.generate_r1cs_witness(vk.alpha_g1);
+        m_beta.generate_r1cs_witness(vk.beta_g2);
+        m_gamma.generate_r1cs_witness(vk.gamma_g2);
+        m_delta.generate_r1cs_witness(vk.delta_g2);
+
+        m_IC[0].generate_r1cs_witness(vk.gamma_ABC_g1.first);
+        int i = 1;
+        for( const auto& x: vk.gamma_ABC_g1.rest.indices )
+            m_IC[i++].generate_r1cs_witness(vk.gamma_ABC_g1.rest.values[x]);
+
+        generate_r1cs_witness();
+    }
+};
+
+
+/**
+* Given the verification key variables
+* Pre-compute the miller loop coefficients
+* And the product of e(alpha,beta)
+* This becomes cheaper when used multiple times, to avoid computing coefficients again
+*/
+template<typename ppT>
+class gro16_vk_preprocessor {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef pb_variable<FieldT> FieldVarT;
+    typedef G1_precomputation<ppT> G1precompT;
+    typedef G2_precomputation<ppT> G2precompT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+
+    G1precompT m_alpha;
+    precompute_G1_gadget<ppT> m_alpha_precomp;
+
+    G2precompT m_beta;
+    precompute_G2_gadget<ppT> m_beta_precomp;
+
+    G2precompT m_gamma;
+    precompute_G2_gadget<ppT> m_gamma_precomp;
+
+    G2precompT m_delta;
+    precompute_G2_gadget<ppT> m_delta_precomp;
+
+    Fqk_variable<ppT> m_alphabeta;
+    miller_loop_gadget<ppT> m_alphabeta_loop;
+
+    std::vector<G1VarT> m_IC_raw;
+
+    gro16_vk_preprocessor(
+        protoboard<FieldT> &pb,
+        const gro16_vk_var<ppT> &vk,
+        const std::string &annotation_prefix
+    ) :
+        // Precomputation gadget allocates the result variables
+        m_alpha_precomp(pb, vk.m_alpha, m_alpha, FMT(annotation_prefix, ".alpha_precomp")),
+        m_beta_precomp(pb, vk.m_beta, m_beta, FMT(annotation_prefix, ".beta_precomp")),
+        m_gamma_precomp(pb, vk.m_gamma, m_gamma, FMT(annotation_prefix, ".gamma_precomp")),
+        m_delta_precomp(pb, vk.m_delta, m_delta, FMT(annotation_prefix, ".delta_precomp")),
+        // Miller loop to precompute e(alpha,beta)
+        m_alphabeta(pb, FMT(annotation_prefix, ".alphabeta")),
+        m_alphabeta_loop(pb, m_alpha, m_beta, m_alphabeta, FMT(annotation_prefix, ".alphabeta_miller_loop")),
+        // Input commitment
+        m_IC_raw(vk.m_IC)
+    {
+    }
+
+    void generate_r1cs_constraints()
+    {
+        m_alpha_precomp.generate_r1cs_constraints();
+        m_beta_precomp.generate_r1cs_constraints();
+        m_gamma_precomp.generate_r1cs_constraints();
+        m_delta_precomp.generate_r1cs_constraints();
+
+        m_alphabeta_loop.generate_r1cs_constraints();
+    }
+
+    void generate_r1cs_witness() 
+    {
+        m_alpha_precomp.generate_r1cs_witness();
+        m_beta_precomp.generate_r1cs_witness();
+        m_gamma_precomp.generate_r1cs_witness();
+        m_delta_precomp.generate_r1cs_witness();
+
+        m_alphabeta_loop.generate_r1cs_witness();
+    }
+};
+
+
+/**
+* Holds the input bits
+*/
+template<typename ppT>
+class gro16_inputbits_gadget : public gadget<libff::Fr<ppT>>
+{
+public:
+    typedef libff::Fr<ppT> FieldT;
+
+    const size_t inputs_count;
+    pb_variable_array<FieldT> bits; // Contiguous array of bits
+
+    gro16_inputbits_gadget(
+        protoboard<FieldT> &pb,
+        const size_t n_inputs,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        inputs_count(n_inputs)
+    {
+        assert( inputs_count > 0 );
+        const size_t n_input_bits = FieldT::size_in_bits() * inputs_count;
+        bits.allocate(pb, n_input_bits, FMT(annotation_prefix, ".bits"));
+    }
+
+    gro16_inputbits_gadget(
+        protoboard<FieldT> &pb,
+        pb_variable_array<FieldT> bits,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        inputs_count(bits.size() / FieldT::size_in_bits()),
+        bits(bits)
+    {
+        assert( inputs_count > 0 );
+        assert( (bits.size() % FieldT::size_in_bits()) == 0 );
+    }
+
+    void generate_r1cs_witness()
+    {
+        // ... nothing to do
+        // ... variables have been passed in via constructor
+        // ... values are assumed to have been populated elsewhere
+    }
+
+    /** Fill input bits from field elements */
+    template<typename T>
+    void generate_r1cs_witness(const std::vector<T> inputs)
+    {
+        assert( inputs_count == inputs.size() );
+
+        int i = 0;
+
+        for (const auto &el : inputs)
+        {
+            const auto el_bits = libff::convert_field_element_to_bit_vector(el, T::size_in_bits());
+
+            for( const auto b : el_bits )
+                this->pb.val(bits[i++]) = (b ? 1 : 0);
+        }
+    }
+
+    void generate_r1cs_constraints()
+    {
+        // ... no constraints needed here
+    }
+};
+
+
+
+template<typename ppT>
+class gro16_verifier_gadget : public gadget<libff::Fr<ppT>> {
+public:
+    typedef G1_precomputation<ppT> G1precompT;
+    typedef G2_precomputation<ppT> G2precompT;
+    typedef libff::Fr<ppT> FieldT;
+
+    G1precompT m_A;
+    precompute_G1_gadget<ppT> m_A_precomp;
+
+    G2precompT m_B;
+    precompute_G2_gadget<ppT> m_B_precomp;
+
+    G1precompT m_C;
+    precompute_G1_gadget<ppT> m_C_precomp;
+
+    const G1_variable<ppT> m_acc_result;
+    G1precompT m_acc_result_precomp;
+    precompute_G1_gadget<ppT> m_acc_result_precomp_gadget;
+
+    G1_multiscalar_mul_gadget<ppT> m_acc;
+
+    pairing_product_gadget<ppT> m_ppg;
+    // TODO: calculate input commitment...
+
+    gro16_verifier_gadget(
+        protoboard<FieldT> &pb,
+        const gro16_proof_var<ppT> &proof,
+        const gro16_vk_preprocessor<ppT> &vkp,
+        const gro16_inputbits_gadget<ppT> &bits,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        m_A_precomp(pb, proof.A, m_A, FMT(annotation_prefix, ".A_precompute")),
+        m_B_precomp(pb, proof.B, m_B, FMT(annotation_prefix, ".B_precompute")),
+        m_C_precomp(pb, proof.C, m_C, FMT(annotation_prefix, ".C_precompute")),
+        m_acc_result(pb, ".acc"),
+        m_acc_result_precomp_gadget(pb, m_acc_result, m_acc_result_precomp, FMT(annotation_prefix, ".C_precompute")),
+        m_acc(pb,
+              *vkp.m_IC_raw.begin(),
+              {bits.bits.begin(), bits.bits.end()},
+              FieldT::size_in_bits(),
+              {vkp.m_IC_raw.begin() + 1, vkp.m_IC_raw.end()},    // slice IC[1:]
+              m_acc_result,
+              FMT(annotation_prefix, ".acc_gadget")),
+        m_ppg(pb,
+              {
+                pairing_input_pair<ppT>(m_A, m_B),
+                pairing_input_pair<ppT>(m_acc_result_precomp, vkp.m_gamma),
+                pairing_input_pair<ppT>(m_C, vkp.m_delta)
+              },
+              {vkp.m_alphabeta},
+              FMT(annotation_prefix, ".pairing_product"))
+    {
+        // ... nothing more to do here
+    }
+
+    void generate_r1cs_witness()
+    {
+        m_A_precomp.generate_r1cs_witness();
+        m_B_precomp.generate_r1cs_witness();
+        m_C_precomp.generate_r1cs_witness();
+        m_acc.generate_r1cs_witness();
+        m_acc_result_precomp_gadget.generate_r1cs_witness();
+        m_ppg.generate_r1cs_witness();
+    }
+
+    void generate_r1cs_constraints()
+    {
+        m_A_precomp.generate_r1cs_constraints();
+        m_B_precomp.generate_r1cs_constraints();
+        m_C_precomp.generate_r1cs_constraints();
+        m_acc.generate_r1cs_constraints();
+        m_acc_result_precomp_gadget.generate_r1cs_constraints();
+        m_ppg.generate_r1cs_constraints();
+    }
+};
+
+
+} // libsnark
+

--- a/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
@@ -512,7 +512,7 @@ int main(void)
     libff::start_profiling();
     libff::mnt4_pp::init_public_params();
     libff::mnt6_pp::init_public_params();
-    /*
+
     test_mul<libff::mnt4_Fq2, Fp2_variable, Fp2_mul_gadget>("mnt4_Fp2");
     test_sqr<libff::mnt4_Fq2, Fp2_variable, Fp2_sqr_gadget>("mnt4_Fp2");
 
@@ -563,7 +563,7 @@ int main(void)
 
     test_pairing_product_gadget<libff::mnt4_pp>("mnt4");
     test_pairing_product_gadget<libff::mnt6_pp>("mnt6");
-    */
+
     test_gro16_verifier<libff::mnt4_pp, libff::mnt6_pp>("mnt4", "mnt6");
     test_gro16_verifier<libff::mnt6_pp, libff::mnt4_pp>("mnt6", "mnt4");
 }

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
@@ -167,6 +167,8 @@ std::istream& operator>>(std::istream &in, r1cs_gg_ppzksnark_verification_key<pp
 template<typename ppT>
 class r1cs_gg_ppzksnark_verification_key {
 public:
+    libff::G1<ppT> alpha_g1;
+    libff::G2<ppT> beta_g2;
     libff::GT<ppT> alpha_g1_beta_g2;
     libff::G2<ppT> gamma_g2;
     libff::G2<ppT> delta_g2;
@@ -174,11 +176,14 @@ public:
     accumulation_vector<libff::G1<ppT> > gamma_ABC_g1;
 
     r1cs_gg_ppzksnark_verification_key() = default;
-    r1cs_gg_ppzksnark_verification_key(const libff::GT<ppT> &alpha_g1_beta_g2,
+    r1cs_gg_ppzksnark_verification_key(const libff::G1<ppT> &alpha_g1,
+                                       const libff::G2<ppT> &beta_g2,
                                        const libff::G2<ppT> &gamma_g2,
                                        const libff::G2<ppT> &delta_g2,
                                        const accumulation_vector<libff::G1<ppT> > &gamma_ABC_g1) :
-        alpha_g1_beta_g2(alpha_g1_beta_g2),
+        alpha_g1(alpha_g1),
+        beta_g2(beta_g2),
+        alpha_g1_beta_g2(ppT::reduced_pairing(alpha_g1, beta_g2)),
         gamma_g2(gamma_g2),
         delta_g2(delta_g2),
         gamma_ABC_g1(gamma_ABC_g1)

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -352,8 +352,8 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
     libff::leave_block("Generate R1CS proving key");
 
     libff::enter_block("Generate R1CS verification key");
-    libff::GT<ppT> alpha_g1_beta_g2 = ppT::reduced_pairing(alpha_g1, beta_g2);
-    libff::G2<ppT> gamma_g2 = gamma * G2_gen;
+    //libff::GT<ppT> alpha_g1_beta_g2 = ppT::reduced_pairing(alpha_g1, beta_g2);
+    const libff::G2<ppT> gamma_g2 = gamma * G2_gen;
 
     libff::enter_block("Encode gamma_ABC for R1CS verification key");
     libff::G1<ppT> gamma_ABC_g1_0 = gamma_ABC_0 * g1_generator;
@@ -363,23 +363,25 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
 
     libff::leave_block("Call to r1cs_gg_ppzksnark_generator");
 
-    accumulation_vector<libff::G1<ppT> > gamma_ABC_g1(std::move(gamma_ABC_g1_0), std::move(gamma_ABC_g1_values));
+    const accumulation_vector<libff::G1<ppT> > gamma_ABC_g1(std::move(gamma_ABC_g1_0), std::move(gamma_ABC_g1_values));
 
-    r1cs_gg_ppzksnark_verification_key<ppT> vk = r1cs_gg_ppzksnark_verification_key<ppT>(alpha_g1_beta_g2,
-                                                                                         gamma_g2,
-                                                                                         delta_g2,
-                                                                                         gamma_ABC_g1);
+    auto vk = r1cs_gg_ppzksnark_verification_key<ppT>(
+        alpha_g1,
+        beta_g2,
+        gamma_g2,
+        delta_g2,
+        gamma_ABC_g1);
 
-    r1cs_gg_ppzksnark_proving_key<ppT> pk = r1cs_gg_ppzksnark_proving_key<ppT>(std::move(alpha_g1),
-                                                                               std::move(beta_g1),
-                                                                               std::move(beta_g2),
-                                                                               std::move(delta_g1),
-                                                                               std::move(delta_g2),
-                                                                               std::move(A_query),
-                                                                               std::move(B_query),
-                                                                               std::move(H_query),
-                                                                               std::move(L_query),
-                                                                               std::move(r1cs_copy));
+    auto pk = r1cs_gg_ppzksnark_proving_key<ppT>(std::move(alpha_g1),
+                                                 std::move(beta_g1),
+                                                 std::move(beta_g2),
+                                                 std::move(delta_g1),
+                                                 std::move(delta_g2),
+                                                 std::move(A_query),
+                                                 std::move(B_query),
+                                                 std::move(H_query),
+                                                 std::move(L_query),
+                                                 std::move(r1cs_copy));
 
     pk.print_size();
     vk.print_size();


### PR DESCRIPTION
Implements Groth16 verification gadget, with tests for MNT4 and MNT6.

This requires approx 50k constraints for 3 public inputs.

Uses the equation: `e(A*B) * e(-IC*gamma) * e(-C*delta) * (-alpha*gamma) == 1` in conjunction with the pairing product gadget. This requires only one final exponentiation to verify equality.