### PR TITLE
GM17 verifier gadget for libsnark

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = git://github.com/mbbarbosa/libsnark-supercop.git
 [submodule "depends/libff"]
 	path = depends/libff
-	url = git@github.com:EYBlockchain/zk-swap-libff.git
+	url = git://github.com:EYBlockchain/zk-swap-libff.git
 [submodule "depends/libfqfft"]
 	path = depends/libfqfft
-	url = https://github.com/EYBlockchain/zk-swap-libfqfft.git
+	url = git://github.com/EYBlockchain/zk-swap-libfqfft.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = git@github.com:EYBlockchain/zk-swap-libff.git
 [submodule "depends/libfqfft"]
 	path = depends/libfqfft
-	url = https://github.com/scipr-lab/libfqfft.git
+	url = https://github.com/EYBlockchain/zk-swap-libfqfft.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,12 @@ option(
   ON
 )
 
+option(
+  USE_ASAN
+  "Enable Address Sanitizer"
+  OFF
+)
+
 set(
   OPT_FLAGS
   ""
@@ -218,6 +224,13 @@ endif()
 
 if("${USE_ASM}")
   add_definitions(-DUSE_ASM)
+endif()
+
+if("${USE_ASAN}")
+  set(
+    CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -fsanitize=address"
+  )
 endif()
 
 if("${USE_LINKED_LIBRARIES}")

--- a/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp
+++ b/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp
@@ -38,8 +38,20 @@ public:
     G1_variable(protoboard<FieldT> &pb,
                 const std::string &annotation_prefix);
     G1_variable(protoboard<FieldT> &pb,
+                const pb_linear_combination<FieldT> &X,
+                const pb_linear_combination<FieldT> &Y,
+                const std::string &annotation_prefix);
+    G1_variable(protoboard<FieldT> &pb,
                 const libff::G1<other_curve<ppT> > &P,
                 const std::string &annotation_prefix);
+
+    G1_variable<ppT> negate() const
+    {
+        pb_linear_combination<FieldT> neg_Y;
+        neg_Y.assign(this->pb, this->Y * -1);
+        neg_Y.evaluate(this->pb);
+        return G1_variable<ppT>(this->pb, this->X, neg_Y, FMT(this->annotation_prefix, ".neg"));
+    }
 
     void generate_r1cs_witness(const libff::G1<other_curve<ppT> > &elt);
 

--- a/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc
@@ -18,6 +18,17 @@ namespace libsnark {
 
 template<typename ppT>
 G1_variable<ppT>::G1_variable(protoboard<FieldT> &pb,
+                              const pb_linear_combination<FieldT> &X,
+                              const pb_linear_combination<FieldT> &Y,
+                              const std::string &annotation_prefix) :
+    gadget<FieldT>(pb, annotation_prefix),
+    X(X),
+    Y(Y)
+{
+}
+
+template<typename ppT>
+G1_variable<ppT>::G1_variable(protoboard<FieldT> &pb,
                               const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix)
 {

--- a/libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp
+++ b/libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp
@@ -51,6 +51,8 @@ public:
 
     void generate_r1cs_witness(const libff::G2<other_curve<ppT> > &Q);
 
+    const libff::G2<other_curve<ppT>> get_point();
+
     // (See a comment in r1cs_ppzksnark_verifier_gadget.hpp about why
     // we mark this function noinline.) TODO: remove later
     static size_t __attribute__((noinline)) size_in_bits();

--- a/libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp
+++ b/libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp
@@ -42,6 +42,10 @@ public:
     G2_variable(protoboard<FieldT> &pb,
                 const std::string &annotation_prefix);
     G2_variable(protoboard<FieldT> &pb,
+                std::shared_ptr<Fqe_variable<ppT> > X,
+                std::shared_ptr<Fqe_variable<ppT> > Y,
+                const std::string &annotation_prefix);
+    G2_variable(protoboard<FieldT> &pb,
                 const libff::G2<other_curve<ppT> > &Q,
                 const std::string &annotation_prefix);
 
@@ -80,6 +84,39 @@ public:
     void generate_r1cs_constraints();
     void generate_r1cs_witness();
 };
+
+template<typename ppT>
+class G2_add_gadget : public gadget<libff::Fr<ppT> > {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef libff::Fqe<other_curve<ppT> > FqeT;
+
+    const FieldT minus_one;
+
+    G2_variable<ppT> A;
+    G2_variable<ppT> B;
+
+    Fqe_variable<ppT> lambda;
+    Fqe_variable<ppT> inv;
+    Fqe_variable<ppT> m_D;
+    Fqe_variable<ppT> m_E;
+    Fqe_variable<ppT> m_F;
+    Fqe_variable<ppT> m_G;
+    G2_variable<ppT> result;
+
+    Fqe_mul_gadget<ppT> bxax_mul_inv_gadget;       // (B.X - A.X) * inv
+    Fqe_sqr_gadget<ppT> sqr_lambda_gadget;         // lambda^2
+    Fqe_mul_gadget<ppT> lambda_mul_axcx_gadget;    // lambda * (A.X - C.X)
+    Fqe_mul_gadget<ppT> lambda_mul_bxax_gadget;    // lambda * (B.X - A.X)
+
+    G2_add_gadget(protoboard<FieldT> &pb,
+                  const G2_variable<ppT> &A,
+                  const G2_variable<ppT> &B,
+                  const std::string &annotation_prefix);
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+};
+
 
 } // libsnark
 

--- a/libsnark/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
@@ -24,6 +24,7 @@
 #include <libsnark/gadgetlib1/gadgets/fields/fp4_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/fields/fp6_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.hpp>
 
 namespace libsnark {
 
@@ -61,6 +62,7 @@ public:
 
     typedef libff::mnt6_pp other_curve_type;
 
+    typedef mnt_miller_loop_gadget<libff::mnt4_pp> miller_loop_gadget;
     typedef mnt_e_over_e_miller_loop_gadget<libff::mnt4_pp> e_over_e_miller_loop_gadget_type;
     typedef mnt_e_times_e_over_e_miller_loop_gadget<libff::mnt4_pp> e_times_e_over_e_miller_loop_gadget_type;
     typedef mnt4_final_exp_gadget<libff::mnt4_pp> final_exp_gadget_type;
@@ -91,6 +93,7 @@ public:
 
     typedef libff::mnt4_pp other_curve_type;
 
+    typedef mnt_miller_loop_gadget<libff::mnt6_pp> miller_loop_gadget;
     typedef mnt_e_over_e_miller_loop_gadget<libff::mnt6_pp> e_over_e_miller_loop_gadget_type;
     typedef mnt_e_times_e_over_e_miller_loop_gadget<libff::mnt6_pp> e_times_e_over_e_miller_loop_gadget_type;
     typedef mnt6_final_exp_gadget<libff::mnt6_pp> final_exp_gadget_type;

--- a/libsnark/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
@@ -18,6 +18,8 @@
 
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/curves/mnt753/mnt4753/mnt4753_pp.hpp>
+#include <libff/algebra/curves/mnt753/mnt6753/mnt6753_pp.hpp>
 
 #include <libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/fields/fp3_gadgets.hpp>
@@ -100,6 +102,70 @@ public:
 
     static const constexpr libff::bigint<libff::mnt4_Fr::num_limbs> &pairing_loop_count = libff::mnt4_ate_loop_count;
 };
+
+
+
+/**
+ * Specialization for MNT4753.
+ */
+template<>
+class pairing_selector<libff::mnt4753_pp> {
+public:
+    typedef libff::Fr<libff::mnt4753_pp> FieldT;
+    typedef libff::Fqe<libff::mnt6753_pp> FqeT;
+    typedef libff::Fqk<libff::mnt6753_pp> FqkT;
+
+    typedef Fp3_variable<FqeT> Fqe_variable_type;
+    typedef Fp3_mul_gadget<FqeT> Fqe_mul_gadget_type;
+    typedef Fp3_mul_by_lc_gadget<FqeT> Fqe_mul_by_lc_gadget_type;
+    typedef Fp3_sqr_gadget<FqeT> Fqe_sqr_gadget_type;
+
+    typedef Fp6_variable<FqkT> Fqk_variable_type;
+    typedef Fp6_mul_gadget<FqkT> Fqk_mul_gadget_type;
+    typedef Fp6_mul_by_2345_gadget<FqkT> Fqk_special_mul_gadget_type;
+    typedef Fp6_sqr_gadget<FqkT> Fqk_sqr_gadget_type;
+
+    typedef libff::mnt6753_pp other_curve_type;
+
+    typedef mnt_miller_loop_gadget<libff::mnt4753_pp> miller_loop_gadget;
+    typedef mnt_e_over_e_miller_loop_gadget<libff::mnt4753_pp> e_over_e_miller_loop_gadget_type;
+    typedef mnt_e_times_e_over_e_miller_loop_gadget<libff::mnt4753_pp> e_times_e_over_e_miller_loop_gadget_type;
+    typedef mnt4_final_exp_gadget<libff::mnt4753_pp> final_exp_gadget_type;
+
+    static const constexpr libff::bigint<libff::mnt6753_Fr::num_limbs> &pairing_loop_count = libff::mnt6753_ate_loop_count;
+};
+
+/**
+ * Specialization for MNT6.
+ */
+template<>
+class pairing_selector<libff::mnt6753_pp> {
+public:
+    typedef libff::Fr<libff::mnt6753_pp> FieldT;
+
+    typedef libff::Fqe<libff::mnt4753_pp> FqeT;
+    typedef libff::Fqk<libff::mnt4753_pp> FqkT;
+
+    typedef Fp2_variable<FqeT> Fqe_variable_type;
+    typedef Fp2_mul_gadget<FqeT> Fqe_mul_gadget_type;
+    typedef Fp2_mul_by_lc_gadget<FqeT> Fqe_mul_by_lc_gadget_type;
+    typedef Fp2_sqr_gadget<FqeT> Fqe_sqr_gadget_type;
+
+    typedef Fp4_variable<FqkT> Fqk_variable_type;
+    typedef Fp4_mul_gadget<FqkT> Fqk_mul_gadget_type;
+    typedef Fp4_mul_gadget<FqkT> Fqk_special_mul_gadget_type;
+    typedef Fp4_sqr_gadget<FqkT> Fqk_sqr_gadget_type;
+
+    typedef libff::mnt4753_pp other_curve_type;
+
+    typedef mnt_miller_loop_gadget<libff::mnt6753_pp> miller_loop_gadget;
+    typedef mnt_e_over_e_miller_loop_gadget<libff::mnt6753_pp> e_over_e_miller_loop_gadget_type;
+    typedef mnt_e_times_e_over_e_miller_loop_gadget<libff::mnt6753_pp> e_times_e_over_e_miller_loop_gadget_type;
+    typedef mnt6_final_exp_gadget<libff::mnt6753_pp> final_exp_gadget_type;
+
+    static const constexpr libff::bigint<libff::mnt4753_Fr::num_limbs> &pairing_loop_count = libff::mnt4753_ate_loop_count;
+};
+
 
 } // libsnark
 

--- a/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp
@@ -119,7 +119,6 @@ public:
 
     std::vector<Fqk_variable<ppT> > m_miller_results;
     std::vector<miller_loop_gadget<ppT> > m_miller_loops;
-    std::vector<Fqk_variable<ppT>> m_precomputed_loops;
     std::vector<Fqk_variable<ppT> > m_product_results;
     std::vector<Fqk_mul_gadget<ppT> > m_product;
     std::shared_ptr<final_exp_gadget<ppT> > m_final_exp;

--- a/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp
@@ -119,6 +119,7 @@ public:
 
     std::vector<Fqk_variable<ppT> > m_miller_results;
     std::vector<miller_loop_gadget<ppT> > m_miller_loops;
+    std::vector<Fqk_variable<ppT>> m_precomputed_loops;
     std::vector<Fqk_variable<ppT> > m_product_results;
     std::vector<Fqk_mul_gadget<ppT> > m_product;
     std::shared_ptr<final_exp_gadget<ppT> > m_final_exp;
@@ -126,6 +127,11 @@ public:
 
     pairing_product_gadget(protoboard<FieldT> &pb,
                            const std::vector<pairing_input_pair<ppT>> &pairs,
+                           const std::string &annotation_prefix);
+
+    pairing_product_gadget(protoboard<FieldT> &pb,
+                           const std::vector<pairing_input_pair<ppT>> &pairs,
+                           const std::vector<Fqk_variable<ppT>> &precomputed_loops,
                            const std::string &annotation_prefix);
 
     void generate_r1cs_constraints();

--- a/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.tcc
+++ b/libsnark/gadgetlib1/gadgets/pairing/pairing_checks.tcc
@@ -14,6 +14,7 @@
 #ifndef PAIRING_CHECKS_TCC_
 #define PAIRING_CHECKS_TCC_
 
+
 namespace libsnark {
 
 template<typename ppT>
@@ -87,6 +88,116 @@ void check_e_equals_ee_gadget<ppT>::generate_r1cs_witness()
     compute_ratio->generate_r1cs_witness();
     check_finexp->generate_r1cs_witness();
 }
+
+
+
+template<typename ppT>
+pairing_product_gadget<ppT>::pairing_product_gadget(
+    protoboard<FieldT> &pb,
+    const std::vector<pairing_input_pair<ppT>> &pairs,
+    const std::string &annotation_prefix
+) :
+    gadget<FieldT>(pb, annotation_prefix)
+{
+    assert( pairs.size() > 0 );
+    result_is_one.allocate(pb, FMT(annotation_prefix, ".result_is_one"));
+
+    // XXX: must be reserved, otherwise emplace_back will call destructor on miller loop during move which invalidates shared_ptr
+    m_miller_results.reserve(pairs.size());
+    m_miller_loops.reserve(pairs.size());
+    if( pairs.size() > 1 ) {
+        m_product_results.reserve(pairs.size() - 1);
+        m_product.reserve(pairs.size() - 1);
+    }
+
+    int i = 0;
+    for( const auto &p_ref : pairs )
+    {
+        m_miller_results.emplace_back(pb, FMT(annotation_prefix, ".result_%d", i));
+        m_miller_loops.emplace_back(
+            pb,
+            p_ref.g1,
+            p_ref.g2,
+            m_miller_results[i],
+            FMT(annotation_prefix, ".miller_loop_%d", i));
+
+        if( i > 0 )
+        {
+            m_product_results.emplace_back(pb, FMT(annotation_prefix, ".product_result_%d", i));
+
+            if( m_product_results.size() == 1 )
+            {
+                assert( m_miller_results.size() == 2 );
+                // pr[0] = result[0] * result[1]
+                m_product.emplace_back(
+                    pb,
+                    m_miller_results[0],
+                    m_miller_results.back(),
+                    m_product_results.back(),
+                    FMT(annotation_prefix, ".product_%d", i));
+            }
+            else {
+                // pr[i] = pr[i-1] * result[i]
+                m_product.emplace_back(
+                    pb,
+                    m_product_results[ m_product_results.size() - 2 ] ,  // Previous product
+                    m_miller_results.back(),
+                    m_product_results.back(),
+                    FMT(annotation_prefix, ".product_%d", i));
+            }
+        }
+
+        i += 1;
+    }
+
+    m_final_exp.reset(new final_exp_gadget<ppT>(pb, raw_result(), result_is_one, FMT(annotation_prefix, ".check_is_one")));
+}
+
+
+template<typename ppT>
+void pairing_product_gadget<ppT>::generate_r1cs_constraints()
+{
+    for( auto &m : m_miller_loops )
+        m.generate_r1cs_constraints();
+
+    for( auto &p : m_product )
+        p.generate_r1cs_constraints();
+
+    m_final_exp->generate_r1cs_constraints();
+}
+
+
+template<typename ppT>
+void pairing_product_gadget<ppT>::generate_r1cs_witness()
+{
+    for( auto &m : m_miller_loops )
+        m.generate_r1cs_witness();
+
+    for( auto &p : m_product )
+        p.generate_r1cs_witness();
+
+    m_final_exp->generate_r1cs_witness();
+}
+
+
+template<typename ppT>
+Fqk_variable<ppT>& pairing_product_gadget<ppT>::result()
+{
+    return *m_final_exp->result;
+}
+
+
+template<typename ppT>
+Fqk_variable<ppT>& pairing_product_gadget<ppT>::raw_result()
+{
+    if( m_product_results.size() > 0 ) {
+        return m_product_results.back();
+    }
+
+    // When there is only one pairing, and no product...
+    return m_miller_results.back();
+}
+
 
 } // libsnark
 

--- a/libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp
@@ -105,6 +105,9 @@ template<typename ppT>
 using other_curve = typename pairing_selector<ppT>::other_curve_type;
 
 template<typename ppT>
+using miller_loop_gadget = typename pairing_selector<ppT>::miller_loop_gadget;
+
+template<typename ppT>
 using e_over_e_miller_loop_gadget = typename pairing_selector<ppT>::e_over_e_miller_loop_gadget_type;
 template<typename ppT>
 using e_times_e_over_e_miller_loop_gadget = typename pairing_selector<ppT>::e_times_e_over_e_miller_loop_gadget_type;

--- a/libsnark/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.hpp
@@ -52,8 +52,8 @@ public:
     std::shared_ptr<Fqk_mul_gadget<ppT> > compute_el_inv_q_3_minus_1;
     std::shared_ptr<Fqk_mul_gadget<ppT> > compute_inv_beta;
 
-    std::shared_ptr<exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, libff::mnt6_q_limbs> > compute_w1;
-    std::shared_ptr<exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, libff::mnt6_q_limbs> > compute_w0;
+    std::shared_ptr<exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, other_curve<ppT>::q_limbs> > compute_w1;
+    std::shared_ptr<exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, other_curve<ppT>::q_limbs> > compute_w0;
     std::shared_ptr<Fqk_mul_gadget<ppT> > compute_result;
 
     pb_variable<FieldT> result_is_one;
@@ -90,8 +90,8 @@ public:
     std::shared_ptr<Fqk_mul_gadget<ppT> > compute_el_q_2_minus_1;
     std::shared_ptr<Fqk_mul_gadget<ppT> > compute_el_inv_q_2_minus_1;
 
-    std::shared_ptr<exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, libff::mnt4_q_limbs> > compute_w1;
-    std::shared_ptr<exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, libff::mnt4_q_limbs> > compute_w0;
+    std::shared_ptr<exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, other_curve<ppT>::q_limbs> > compute_w1;
+    std::shared_ptr<exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, other_curve<ppT>::q_limbs> > compute_w0;
     std::shared_ptr<Fqk_mul_gadget<ppT> > compute_result;
 
     pb_variable<FieldT> result_is_one;

--- a/libsnark/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.tcc
+++ b/libsnark/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.tcc
@@ -51,11 +51,11 @@ mnt4_final_exp_gadget<ppT>::mnt4_final_exp_gadget(protoboard<FieldT> &pb,
     compute_el_inv_q_3_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_inv_q_3, el, *el_inv_q_3_minus_1, FMT(annotation_prefix, " compute_el_inv__q_3_minus_1")));
     compute_inv_beta.reset(new Fqk_mul_gadget<ppT>(pb, *inv_alpha, *el_inv_q_3_minus_1, *inv_beta, FMT(annotation_prefix, " compute_inv_beta")));
 
-    compute_w1.reset(new exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, libff::mnt6_q_limbs>(
-        pb, *beta_q, libff::mnt6_final_exponent_last_chunk_w1, *w1, FMT(annotation_prefix, " compute_w1")));
+    compute_w1.reset(new exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, other_curve<ppT>::q_limbs>(
+        pb, *beta_q, other_curve<ppT>::final_exponent_last_chunk_w1, *w1, FMT(annotation_prefix, " compute_w1")));
 
-    compute_w0.reset(new exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, libff::mnt6_q_limbs>(
-        pb, (libff::mnt6_final_exponent_last_chunk_is_w0_neg ? *inv_beta : *beta), libff::mnt6_final_exponent_last_chunk_abs_of_w0, *w0, FMT(annotation_prefix, " compute_w0")));
+    compute_w0.reset(new exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, other_curve<ppT>::q_limbs>(
+        pb, (other_curve<ppT>::final_exponent_last_chunk_is_w0_neg ? *inv_beta : *beta), other_curve<ppT>::final_exponent_last_chunk_abs_of_w0, *w0, FMT(annotation_prefix, " compute_w0")));
 
     compute_result.reset(new Fqk_mul_gadget<ppT>(pb, *w1, *w0, *result, FMT(annotation_prefix, " compute_result")));
 }
@@ -134,10 +134,10 @@ mnt6_final_exp_gadget<ppT>::mnt6_final_exp_gadget(protoboard<FieldT> &pb,
     compute_el_q_2_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_q_2, *el_inv, *el_q_2_minus_1, FMT(annotation_prefix, " compute_el_q_2_minus_1")));
     compute_el_inv_q_2_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_inv_q_2, el, *el_inv_q_2_minus_1, FMT(annotation_prefix, " compute_el_inv_q_2_minus_1")));
 
-    compute_w1.reset(new exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, libff::mnt4_q_limbs>(
-        pb, *el_q_3_minus_q, libff::mnt4_final_exponent_last_chunk_w1, *w1, FMT(annotation_prefix, " compute_w1")));
-    compute_w0.reset(new exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, libff::mnt4_q_limbs>(
-        pb, (libff::mnt4_final_exponent_last_chunk_is_w0_neg ? *el_inv_q_2_minus_1 : *el_q_2_minus_1), libff::mnt4_final_exponent_last_chunk_abs_of_w0, *w0, FMT(annotation_prefix, " compute_w0")));
+    compute_w1.reset(new exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, other_curve<ppT>::q_limbs>(
+        pb, *el_q_3_minus_q, other_curve<ppT>::final_exponent_last_chunk_w1, *w1, FMT(annotation_prefix, " compute_w1")));
+    compute_w0.reset(new exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, other_curve<ppT>::q_limbs>(
+        pb, (other_curve<ppT>::final_exponent_last_chunk_is_w0_neg ? *el_inv_q_2_minus_1 : *el_q_2_minus_1), other_curve<ppT>::final_exponent_last_chunk_abs_of_w0, *w0, FMT(annotation_prefix, " compute_w0")));
     compute_result.reset(new Fqk_mul_gadget<ppT>(pb, *w1, *w0, *result, FMT(annotation_prefix, " compute_result")));
 }
 

--- a/libsnark/gadgetlib1/gadgets/pairing/weierstrass_precomputation.hpp
+++ b/libsnark/gadgetlib1/gadgets/pairing/weierstrass_precomputation.hpp
@@ -67,9 +67,10 @@ public:
             gadget<FieldT>(pb, annotation_prefix),
             precomp(precomp)
     {
+        const auto &twist = other_curve<ppT>::Fq2_twist;
         pb_linear_combination<FieldT> c0, c1;
-        c0.assign(pb, P.Y * ((libff::mnt4_twist).squared().c0));
-        c1.assign(pb, P.Y * ((libff::mnt4_twist).squared().c1));
+        c0.assign(pb, P.Y * (twist.squared().c0));
+        c1.assign(pb, P.Y * (twist.squared().c1));
 
         precomp.P.reset(new G1_variable<ppT>(P));
         precomp.PY_twist_squared.reset(new Fqe_variable<ppT>(pb, c0, c1, FMT(annotation_prefix, " PY_twist_squared")));
@@ -84,10 +85,11 @@ public:
         gadget<FieldT>(pb, annotation_prefix),
             precomp(precomp)
     {
+        const auto &twist = other_curve<ppT>::Fq3_twist;
         pb_linear_combination<FieldT> c0, c1, c2;
-        c0.assign(pb, P.Y * ((libff::mnt6_twist).squared().c0));
-        c1.assign(pb, P.Y * ((libff::mnt6_twist).squared().c1));
-        c2.assign(pb, P.Y * ((libff::mnt6_twist).squared().c2));
+        c0.assign(pb, P.Y * (twist.squared().c0));
+        c1.assign(pb, P.Y * (twist.squared().c1));
+        c2.assign(pb, P.Y * (twist.squared().c2));
 
         precomp.P.reset(new G1_variable<ppT>(P));
         precomp.PY_twist_squared.reset(new Fqe_variable<ppT>(pb, c0, c1, c2, FMT(annotation_prefix, " PY_twist_squared")));

--- a/libsnark/gadgetlib1/gadgets/verifiers/gm17.hpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/gm17.hpp
@@ -1,0 +1,648 @@
+#pragma once
+
+#include <libsnark/gadgetlib1/gadgets/basic_gadgets.hpp>
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp>
+
+
+namespace libsnark {
+
+
+/**
+* Holds a GM17 proof (but not its inputs)
+* The A, B and C points are validated
+*/
+template<typename ppT>
+class gm17_proof_var : public gadget<libff::Fr<ppT> > {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+    typedef pb_variable<FieldT> FieldVarT;
+
+    G1VarT A;
+    G2VarT B;
+    G1VarT C;
+
+    // XXX: do we need a mode where we don't validate the proof points?
+    G1_checker_gadget<ppT> m_A_checker;
+    G2_checker_gadget<ppT> m_B_checker;
+    G1_checker_gadget<ppT> m_C_checker;
+
+    gm17_proof_var(
+        protoboard<FieldT> &pb,
+        const G1VarT &_A,
+        const G2VarT &_B,
+        const G1VarT &_C,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        A(_A),
+        B(_B),
+        C(_C),
+        m_A_checker(pb, A, FMT(annotation_prefix, ".A_checker")),
+        m_B_checker(pb, B, FMT(annotation_prefix, ".B_checker")),
+        m_C_checker(pb, C, FMT(annotation_prefix, ".C_checker"))
+    { }
+
+    gm17_proof_var(
+        protoboard<FieldT> &pb,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        A(pb, FMT(annotation_prefix, ".A")),
+        B(pb, FMT(annotation_prefix, ".B")),
+        C(pb, FMT(annotation_prefix, ".C")),
+        m_A_checker(pb, A, FMT(annotation_prefix, ".A_checker")),
+        m_B_checker(pb, B, FMT(annotation_prefix, ".B_checker")),
+        m_C_checker(pb, C, FMT(annotation_prefix, ".C_checker"))
+    {
+
+    }
+
+    void generate_r1cs_constraints()
+    {
+        m_A_checker.generate_r1cs_constraints();
+        m_B_checker.generate_r1cs_constraints();
+        m_C_checker.generate_r1cs_constraints();
+    }
+
+    /** Fill variables from proof with inputs */
+    void generate_r1cs_witness(
+        const r1cs_se_ppzksnark_proof<other_curve<ppT>> &proof
+    ) {
+        A.generate_r1cs_witness(proof.A);
+        m_A_checker.generate_r1cs_witness();
+
+        B.generate_r1cs_witness(proof.B);
+        m_B_checker.generate_r1cs_witness();
+
+        C.generate_r1cs_witness(proof.C);
+        m_C_checker.generate_r1cs_witness();
+    }
+
+    void print(const char *prefix="")
+    {
+        std::cout << prefix << ".A.X = "; this->pb.lc_val(A.X).print();
+        std::cout << prefix << ".A.Y = "; this->pb.lc_val(A.Y).print();
+        std::cout << prefix << ".B.X = "; this->B.X->get_element().print();
+        std::cout << prefix << ".B.Y = "; this->B.Y->get_element().print();
+        std::cout << prefix << ".C.X = "; this->pb.lc_val(C.X).print();
+        std::cout << prefix << ".C.Y = "; this->pb.lc_val(C.Y).print();
+    }
+};
+
+
+
+/**
+* Holds a Groth16 verification key as variables
+* The points of the verification key are validated
+* This will be given to the preprocessor gadget
+*/
+template<typename ppT>
+class gm17_vk_var : public gadget<libff::Fr<ppT> > {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+
+    G1VarT G_alpha;	// G^{\alpha}
+    G1VarT G_gamma;	// G^{\gamma}
+    G2VarT H;			// H
+    G2VarT H_beta;	// H^{\beta}
+    G2VarT H_gamma;	// H^{\gamma}
+
+    const size_t n_inputs;
+    std::vector<G1VarT> query;
+
+    std::vector<G1_checker_gadget<ppT>> m_g1_checkers;
+    std::vector<G2_checker_gadget<ppT>> m_g2_checkers;
+
+    void _init_checkers()
+    {
+        const auto annotation_prefix = this->annotation_prefix;
+
+        m_g1_checkers.reserve(n_inputs + 3);
+        m_g1_checkers.emplace_back(this->pb, G_alpha, FMT(annotation_prefix, ".G_alpha_checker"));
+        m_g1_checkers.emplace_back(this->pb, G_gamma, FMT(annotation_prefix, ".G_gamma_checker"));
+
+        assert( n_inputs > 0 );
+        for( size_t i = 0; i < (n_inputs+1); i++ )
+        {
+            query.emplace_back(this->pb, FMT(annotation_prefix, ".input_%d", i));
+            m_g1_checkers.emplace_back(this->pb, query.back(), FMT(annotation_prefix, ".query_checker_%d", i));
+        }
+
+        m_g2_checkers.reserve(3);
+        m_g2_checkers.emplace_back(this->pb, H, FMT(annotation_prefix, ".H_checker"));
+        m_g2_checkers.emplace_back(this->pb, H_beta, FMT(annotation_prefix, ".H_beta_checker"));
+        m_g2_checkers.emplace_back(this->pb, H_gamma, FMT(annotation_prefix, ".H_gamma_checker"));
+    }
+
+    /**
+    * Construct new variables to hold the verification key
+    * For when the verification key is a secret input
+    */
+    gm17_vk_var(
+        protoboard<FieldT> &pb,
+        size_t _n_inputs,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        G_alpha(pb, FMT(annotation_prefix, ".G_alpha")),
+        G_gamma(pb, FMT(annotation_prefix, ".G_gamma")),
+        H(pb, FMT(annotation_prefix, ".H")),
+        H_beta(pb, FMT(annotation_prefix, ".H_beta")),
+        H_gamma(pb, FMT(annotation_prefix, ".H_gamma")),
+        n_inputs(_n_inputs)
+    {
+        _init_checkers();
+    }
+
+    /**
+    * Fill verification key from already existing variables
+    * When the verification key comes from somewhere else within the circuit
+    */
+    gm17_vk_var(
+        protoboard<FieldT> &pb,
+        const G1VarT &G_alpha,
+        const G1VarT &G_gamma,
+        const G2VarT &H,
+        const G2VarT &H_beta,
+        const G2VarT &H_gamma,
+        const std::vector<G1VarT> &IC,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        G_alpha(G_alpha),
+        G_gamma(G_gamma),
+        H(H),
+        H_beta(H_beta),
+        H_gamma(H_gamma),
+        n_inputs(IC.size()-1),  // IC always includes the implicit 'ONE' constant as the first element
+        query(IC)
+    {
+        _init_checkers();
+    }
+
+    void generate_r1cs_constraints()
+    {
+        for( auto &gadget : m_g1_checkers )
+            gadget.generate_r1cs_constraints();
+
+        for( auto &gadget : m_g2_checkers )
+            gadget.generate_r1cs_constraints();
+    }
+
+    void generate_r1cs_witness()
+    {
+        for( auto &gadget : m_g1_checkers )
+            gadget.generate_r1cs_witness();
+
+        for( auto &gadget : m_g2_checkers )
+            gadget.generate_r1cs_witness();
+    }
+
+    template<typename T>
+    void generate_r1cs_witness(
+        const r1cs_se_ppzksnark_verification_key<T> &vk
+    ) {
+        G_alpha.generate_r1cs_witness(vk.G_alpha);
+        G_gamma.generate_r1cs_witness(vk.G_gamma);
+        H.generate_r1cs_witness(vk.H);
+        H_beta.generate_r1cs_witness(vk.H_beta);
+        H_gamma.generate_r1cs_witness(vk.H_gamma);
+
+        assert( vk.query.size() == n_inputs + 1 );
+        int i = 0;
+        for( const auto& x: vk.query ) {
+            query[i++].generate_r1cs_witness(x);
+        }
+
+        generate_r1cs_witness();
+    }
+
+    void print(const char *prefix="")
+    {
+        std::cout << prefix << ".G_alpha.X = "; this->pb.lc_val(G_alpha.X).print();
+        std::cout << prefix << ".G_alpha.Y = "; this->pb.lc_val(G_alpha.Y).print();
+
+        std::cout << prefix << ".G_gamma.X = "; this->pb.lc_val(G_gamma.X).print();
+        std::cout << prefix << ".G_gamma.Y = "; this->pb.lc_val(G_gamma.Y).print();
+
+		std::cout << prefix << ".H.X = "; H.X.get_element().print();
+        std::cout << prefix << ".H.Y = "; H.Y.get_element().print();
+
+        std::cout << prefix << ".H_beta.X = "; H_beta.X.get_element().print();
+        std::cout << prefix << ".H_beta.Y = "; H_beta.Y.get_element().print();
+
+        std::cout << prefix << ".H_gamma.X = "; H_gamma.X.get_element().print();
+        std::cout << prefix << ".H_gamma.Y = "; H_gamma.Y.get_element().print();
+
+        int i = 0;
+        for( const auto &el : query )
+        {
+        	std::cout << prefix << ".query["<<i<<".X = "; this->pb.lc_val(el.X).print();
+        	std::cout << prefix << ".query["<<i<<".Y = "; this->pb.lc_val(el.Y).print();
+        	i += 1;
+        }
+    }
+};
+
+
+template<typename ppT>
+class gm17_vk_preprocessor {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef pb_variable<FieldT> FieldVarT;
+    typedef G1_precomputation<ppT> G1precompT;
+    typedef G2_precomputation<ppT> G2precompT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+
+    G1precompT G_alpha;
+    precompute_G1_gadget<ppT> m_G_alpha_precomp;
+
+    G1VarT neg_G_gamma;
+    G1precompT G_gamma;
+    precompute_G1_gadget<ppT> m_G_gamma_precomp;
+
+    G2precompT H;
+    precompute_G2_gadget<ppT> m_H_precomp;
+
+    G2precompT H_beta;
+    precompute_G2_gadget<ppT> m_H_beta_precomp;
+
+    G2precompT H_gamma;
+    precompute_G2_gadget<ppT> m_H_gamma_precomp;
+
+    Fqk_variable<ppT> G_alpha_H_beta;
+    miller_loop_gadget<ppT> m_G_alpha_H_beta_loop;
+
+    gm17_vk_preprocessor(
+        protoboard<FieldT> &pb,
+        const gm17_vk_var<ppT> &vk,
+        const std::string &annotation_prefix
+    ) :
+        // Precomputation gadget allocates the result variables
+        m_G_alpha_precomp(pb, vk.G_alpha, G_alpha, FMT(annotation_prefix, ".G_alpha_precomp")),
+        neg_G_gamma(vk.G_gamma.negate()),
+        m_G_gamma_precomp(pb, neg_G_gamma, G_gamma, FMT(annotation_prefix, ".G_gamma_precomp")),
+        m_H_precomp(pb, vk.H, H, FMT(annotation_prefix, ".H_precomp")),
+        m_H_beta_precomp(pb, vk.H_beta, H_beta, FMT(annotation_prefix, ".H_beta_precomp")),
+        m_H_gamma_precomp(pb, vk.H_gamma, H_gamma, FMT(annotation_prefix, ".H_gamma_precomp")),
+        // Miller loop to precompute e(alpha,beta)
+        G_alpha_H_beta(pb, FMT(annotation_prefix, ".G_alpha_H_beta")),
+        m_G_alpha_H_beta_loop(pb, G_alpha, H_beta, G_alpha_H_beta, FMT(annotation_prefix, ".e(G_alpha,H_beta_loop)"))
+    {
+    }
+
+    /* Verification key will be constant, no checker gadgets are necessary, only precomputation */
+    gm17_vk_preprocessor(
+        protoboard<FieldT> &pb,
+        const r1cs_se_ppzksnark_verification_key<ppT> &vk,
+        const std::string &annotation_prefix
+    ) :
+        // Precomputation gadget allocates the result variables
+        m_G_alpha_precomp(pb, vk.G_alpha, G_alpha, FMT(annotation_prefix, ".G_alpha_precomp")),
+        neg_G_gamma(vk.G_gamma.X, -vk.G_gamma.Y),
+        m_G_gamma_precomp(pb, neg_G_gamma, G_gamma, FMT(annotation_prefix, ".G_gamma_precomp")),
+        m_H_precomp(pb, vk.H, H, FMT(annotation_prefix, ".H_precomp")),
+        m_H_beta_precomp(pb, vk.H_beta, H_beta, FMT(annotation_prefix, ".H_beta_precomp")),
+        m_H_gamma_precomp(pb, vk.H_gamma, H_gamma, FMT(annotation_prefix, ".H_gamma_precomp")),
+        // Miller loop to precompute e(alpha,beta)
+        G_alpha_H_beta(pb, FMT(annotation_prefix, ".G_alpha_H_beta")),
+        m_G_alpha_H_beta_loop(pb, G_alpha, H_beta, G_alpha_H_beta, FMT(annotation_prefix, ".e(G_alpha,H_beta_loop)"))
+    {
+    }
+
+    void generate_r1cs_constraints()
+    {
+        m_G_alpha_precomp.generate_r1cs_constraints();
+        m_G_gamma_precomp.generate_r1cs_constraints();
+        m_H_precomp.generate_r1cs_constraints();
+        m_H_beta_precomp.generate_r1cs_constraints();
+        m_H_gamma_precomp.generate_r1cs_constraints();
+
+        m_G_alpha_H_beta_loop.generate_r1cs_constraints();
+    }
+
+    void generate_r1cs_witness() 
+    {
+    	m_G_alpha_precomp.generate_r1cs_witness();
+        m_G_gamma_precomp.generate_r1cs_witness();
+        m_H_precomp.generate_r1cs_witness();
+        m_H_beta_precomp.generate_r1cs_witness();
+        m_H_gamma_precomp.generate_r1cs_witness();
+
+        m_G_alpha_H_beta_loop.generate_r1cs_witness();
+    }
+
+    void print(const char *prefix="") {
+
+    }
+};
+
+
+
+
+/**
+* Holds the input bits
+* XXX: duplicates gro16_inputbits_gadget
+*/
+template<typename ppT>
+class gm17_inputbits_gadget : public gadget<libff::Fr<ppT>>
+{
+public:
+    typedef libff::Fr<ppT> FieldT;
+
+    const size_t inputs_count;
+    pb_variable_array<FieldT> bits; // Contiguous array of bits
+
+    gm17_inputbits_gadget(
+        protoboard<FieldT> &pb,
+        const size_t n_inputs,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        inputs_count(n_inputs)
+    {
+        assert( inputs_count > 0 );
+        const size_t n_input_bits = FieldT::size_in_bits() * inputs_count;
+        bits.allocate(pb, n_input_bits, FMT(annotation_prefix, ".bits"));
+    }
+
+    gm17_inputbits_gadget(
+        protoboard<FieldT> &pb,
+        const pb_variable_array<FieldT> bits,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        inputs_count(bits.size() / FieldT::size_in_bits()),
+        bits(bits)
+    {
+        assert( inputs_count > 0 );
+        assert( (bits.size() % FieldT::size_in_bits()) == 0 );
+    }
+
+    void generate_r1cs_witness()
+    {
+        // ... nothing to do
+        // ... variables have been passed in via constructor
+        // ... values are assumed to have been populated elsewhere
+    }
+
+    /** Fill input bits from field elements */
+    template<typename T>
+    void generate_r1cs_witness(const std::vector<T> inputs)
+    {
+        assert( inputs_count == inputs.size() );
+
+        int i = 0;
+        for (const auto &el : inputs)
+        {
+            const auto el_bits = libff::convert_field_element_to_bit_vector(el, T::size_in_bits());
+            for( const auto b : el_bits ) {
+                this->pb.val(bits[i++]) = (b ? 1 : 0);
+            }
+        }
+    }
+
+    void generate_r1cs_constraints()
+    {
+        // ... no constraints needed here
+    }
+
+    void print(const char *prefix="") {
+    }
+};
+
+
+
+
+
+/*
+//
+// e(A*G^{alpha}, B*H^{beta}) = e(G^{alpha}, H^{beta}) * e(G^{psi}, H^{gamma})
+//                              * e(C, H)
+// where psi = \sum_{i=0}^l input_i pvk.query[i]
+//
+if (!Pairing_v1.pairingProd4(
+		vk.Galpha, vk.Hbeta,
+		vk_dot_inputs, vk.Hgamma,
+		proof.C, vk.H,
+		Pairing_v1.negate(Pairing_v1.addition(proof.A, vk.Galpha)), Pairing_v1.addition2(proof.B, vk.Hbeta))) {
+  return 1;
+}
+
+
+//
+// e(A, H^{gamma}) = e(G^{gamma}, B)
+//
+if (!Pairing_v1.pairingProd2(proof.A, vk.Hgamma, Pairing_v1.negate(vk.Ggamma), proof.B)) {
+  return 2;
+}
+
+
+// This translates into:
+
+// a = miller_loop(vk.G_alpha, vk.H_beta)
+a_1 = g1_prep(vk.G_alpha)
+a_2 = g2_prep(vk.H_beta)
+a = miller_loop(a_1, a_2)
+
+// b = miller_loop(IC, vk.H_gamma)
+b_1 = g1_prep(IC)
+b_2 = g2_prep(vk.H_gamma)
+b = miller_loop(b_1, b_2)
+
+// c = miller_loop(C, vk.H)
+c_1 = g1_prep(C)
+c_2 = g2_prep(vk.H)
+c = miller_loop(c_1, c_2)
+
+d = g1_add(proof.A, vk.G_alpha)
+e = g2_add(proof.B, vk.H_beta)
+f = g1_neg(d)
+
+// g = miller_loop(f, e)
+g_1 = g1_prep(f)
+g_2 = g2_prep(e)
+g = miller_loop(g_1, g_2)
+assert ppg([a, b, c, g])
+
+// h = miller_loop(proof.A, vk.H_gamma)
+h_1 = g1_prep(proof.A)
+h_2 = g2_prep(vk.H_gamma)
+h = miller_loop(h_1, h_2)
+
+i = g1_neg(vk.G_gamma)
+// j = miller_loop(i, proof.B)
+j_1 = g1_prep(i)
+j_2 = g2_prep(proof.B)
+j = miller_loop(j_1, j_2)
+assert ppg([h, j])
+*/
+template<typename ppT>
+class gm17_verifier_gadget : public gadget<libff::Fr<ppT>> {
+public:
+    typedef G1_precomputation<ppT> G1precompT;
+    typedef G2_precomputation<ppT> G2precompT;
+    typedef libff::Fr<ppT> FieldT;
+
+    G1_variable<ppT> m_acc_result;
+    G1precompT m_acc_result_precomp;
+    precompute_G1_gadget<ppT> m_acc_result_precomp_gadget;
+    G1_multiscalar_mul_gadget<ppT> m_acc;
+
+    // d = g1_add(proof.A, vk.G_alpha)
+    G1_variable<ppT> d;
+    G1_add_gadget<ppT> d_gadget;
+
+    // e = g2_add(proof.B, vk.H_beta)
+    //G2_variable<ppT> e; // XXX: G2_addition gadget owns output
+    G2_add_gadget<ppT> e_gadget;
+
+    // f = g1_neg(d)
+    G1_variable<ppT> f;
+
+    G1_precomputation<ppT> proof_C_precomp;
+    precompute_G1_gadget<ppT> proof_C_precomp_gadget;
+
+    // g = miller_loop(f, e)
+    G1_precomputation<ppT> g_1;
+    precompute_G1_gadget<ppT> g_1_gadget;
+    G2_precomputation<ppT> g_2;
+    precompute_G2_gadget<ppT> g_2_gadget;
+
+    // assert ppg([a, b, c, g])
+    pairing_product_gadget<ppT> ppg_abcg;
+
+    // h = miller_loop(proof.A, vk.H_gamma)
+    G1_precomputation<ppT> proof_A_precomp;
+    precompute_G1_gadget<ppT> proof_A_precomp_gadget;
+    G2_precomputation<ppT> proof_B_precomp;
+    precompute_G2_gadget<ppT> proof_B_precomp_gadget;
+
+    // assert ppg([h, j])
+    pairing_product_gadget<ppT> ppg_hj;
+
+    std::vector<precompute_G1_gadget<ppT>*> g1_precomp_gadgets;
+    std::vector<precompute_G2_gadget<ppT>*> g2_precomp_gadgets;
+
+    gm17_verifier_gadget(
+        protoboard<FieldT> &pb,
+        const gm17_proof_var<ppT> &proof,
+        const gm17_vk_var<ppT> &vk,
+        const gm17_vk_preprocessor<ppT> &vkp,
+        const gm17_inputbits_gadget<ppT> &bits,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+
+        m_acc_result(pb, ".acc"),
+        m_acc_result_precomp_gadget(pb, m_acc_result, m_acc_result_precomp, FMT(annotation_prefix, ".acc_precompute")),
+        m_acc(pb,
+              vk.query[0],
+              {bits.bits.begin(), bits.bits.end()},
+              FieldT::size_in_bits(),
+              {vk.query.begin() + 1, vk.query.end()},
+              m_acc_result,
+              FMT(annotation_prefix, ".acc_gadget")),
+
+
+        d(pb, FMT(annotation_prefix, ".d")),
+        d_gadget(pb, proof.A, vk.G_alpha, d, FMT(annotation_prefix, ".d_gadget")),
+        e_gadget(pb, proof.B, vk.H_beta, FMT(annotation_prefix, ".e_gadget")),
+
+        f(d.negate()),
+
+        proof_C_precomp_gadget(pb, proof.C, proof_C_precomp, FMT(annotation_prefix, ".proof_C_precomp_gadget")),
+
+        g_1_gadget(pb, f, g_1, FMT(annotation_prefix, ".g_1_gadget")),
+        g_2_gadget(pb, e_gadget.result, g_2, FMT(annotation_prefix, ".g_2_gadget")),
+
+        ppg_abcg(pb,
+            {
+                pairing_input_pair<ppT>(vkp.G_alpha, vkp.H_beta),
+                pairing_input_pair<ppT>(m_acc_result_precomp, vkp.H_gamma),
+                pairing_input_pair<ppT>(proof_C_precomp, vkp.H),
+                pairing_input_pair<ppT>(g_1, g_2)
+            }, FMT(annotation_prefix, ".ppg_abcg")),
+
+        proof_A_precomp_gadget(pb, proof.A, proof_A_precomp, FMT(annotation_prefix, ".proof_A_precomp_gadget")),
+        proof_B_precomp_gadget(pb, proof.B, proof_B_precomp, FMT(annotation_prefix, ".proof_B_precomp_gadget")),
+
+        ppg_hj(pb,
+            {
+                pairing_input_pair<ppT>(proof_A_precomp, vkp.H_gamma),
+                pairing_input_pair<ppT>(vkp.G_gamma, proof_B_precomp)
+            }, FMT(annotation_prefix, ".ppg_hj"))
+    {
+        g1_precomp_gadgets.emplace_back(&g_1_gadget);
+        g1_precomp_gadgets.emplace_back(&proof_A_precomp_gadget);
+        g1_precomp_gadgets.emplace_back(&proof_C_precomp_gadget);
+
+        g2_precomp_gadgets.emplace_back(&g_2_gadget);
+        g2_precomp_gadgets.emplace_back(&proof_B_precomp_gadget);
+    }
+
+    void generate_r1cs_witness()
+    {
+        d_gadget.generate_r1cs_witness();
+        e_gadget.generate_r1cs_witness();
+        proof_C_precomp_gadget.generate_r1cs_witness();
+        g_1_gadget.generate_r1cs_witness();
+        g_2_gadget.generate_r1cs_witness();
+        proof_A_precomp_gadget.generate_r1cs_witness();
+        proof_B_precomp_gadget.generate_r1cs_witness();
+
+        for( auto &x : g1_precomp_gadgets ) {
+            x->generate_r1cs_witness();
+        }
+
+        for( auto &x : g2_precomp_gadgets ) {
+            x->generate_r1cs_witness();
+        }
+
+        ppg_abcg.generate_r1cs_witness();
+        ppg_hj.generate_r1cs_witness();
+    }
+
+    void generate_r1cs_constraints()
+    {
+        d_gadget.generate_r1cs_constraints();
+        e_gadget.generate_r1cs_constraints();
+        proof_C_precomp_gadget.generate_r1cs_constraints();
+        g_1_gadget.generate_r1cs_constraints();
+        g_2_gadget.generate_r1cs_constraints();
+        proof_A_precomp_gadget.generate_r1cs_constraints();
+        proof_B_precomp_gadget.generate_r1cs_constraints();
+
+        for( auto &x : g1_precomp_gadgets ) {
+            x->generate_r1cs_constraints();
+        }
+
+        for( auto &x : g2_precomp_gadgets ) {
+            x->generate_r1cs_constraints();
+        }
+
+        ppg_abcg.generate_r1cs_constraints();
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(ppg_abcg.result_is_one, 1, 1), FMT(this->annotation_prefix, ".ppg_abcg.result must be 1"));
+
+        ppg_hj.generate_r1cs_constraints();
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(ppg_hj.result_is_one, 1, 1), FMT(this->annotation_prefix, ".ppg_hj.result must be 1"));
+    }
+
+    void print(const char *prefix="") {
+        std::cout << prefix << ".m_acc_result.X = "; this->pb.lc_val(m_acc_result.X).print();
+        std::cout << prefix << ".m_acc_result.Y = "; this->pb.lc_val(m_acc_result.Y).print();        
+    }
+};
+
+
+// libsnark
+}

--- a/libsnark/gadgetlib1/gadgets/verifiers/gm17.hpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/gm17.hpp
@@ -357,88 +357,6 @@ public:
 };
 
 
-
-
-/**
-* Holds the input bits
-* XXX: duplicates gro16_inputbits_gadget
-*/
-template<typename ppT>
-class gm17_inputbits_gadget : public gadget<libff::Fr<ppT>>
-{
-public:
-    typedef libff::Fr<ppT> FieldT;
-
-    const size_t inputs_count;
-    pb_variable_array<FieldT> bits; // Contiguous array of bits
-
-    gm17_inputbits_gadget(
-        protoboard<FieldT> &pb,
-        const size_t n_inputs,
-        const std::string &annotation_prefix
-    ) :
-        gadget<FieldT>(pb, annotation_prefix),
-        inputs_count(n_inputs)
-    {
-        assert( inputs_count > 0 );
-        const size_t n_input_bits = FieldT::size_in_bits() * inputs_count;
-        bits.allocate(pb, n_input_bits, FMT(annotation_prefix, ".bits"));
-    }
-
-    gm17_inputbits_gadget(
-        protoboard<FieldT> &pb,
-        const pb_variable_array<FieldT> bits,
-        const std::string &annotation_prefix
-    ) :
-        gadget<FieldT>(pb, annotation_prefix),
-        inputs_count(bits.size() / FieldT::size_in_bits()),
-        bits(bits)
-    {
-        assert( inputs_count > 0 );
-        assert( (bits.size() % FieldT::size_in_bits()) == 0 );
-    }
-
-    void generate_r1cs_witness()
-    {
-        // ... nothing to do
-        // ... variables have been passed in via constructor
-        // ... values are assumed to have been populated elsewhere
-    }
-
-    /** Fill input bits from field elements */
-    template<typename T>
-    void generate_r1cs_witness(const std::vector<T> inputs)
-    {
-        assert( inputs_count == inputs.size() );
-
-        int i = 0;
-        for (const auto &el : inputs)
-        {
-            const auto el_bits = libff::convert_field_element_to_bit_vector(el, T::size_in_bits());
-            for( const auto b : el_bits ) {
-                this->pb.val(bits[i++]) = (b ? 1 : 0);
-            }
-        }
-    }
-
-    void generate_r1cs_constraints(bool enforce_bitness = true)
-    {
-        if( enforce_bitness )
-        {
-            int i = 0;
-            for( auto &bit_var : bits )
-            {
-                generate_boolean_r1cs_constraint<FieldT>(this->pb, bit_var, FMT(this->annotation_prefix, ".bitness[%d]", i));
-                i += 1;
-            }
-        }
-    }
-
-    void print(const char *prefix="") {
-    }
-};
-
-
 template<typename ppT>
 class gm17_verifier_gadget : public gadget<libff::Fr<ppT>> {
 public:
@@ -490,7 +408,7 @@ public:
         protoboard<FieldT> &pb,
         const gm17_proof_var<ppT> &proof,
         const gm17_vk_preprocessor<ppT> &vkp,
-        const gm17_inputbits_gadget<ppT> &bits,
+        const libsnark::pb_variable_array<FieldT> &bits,
         const std::string &annotation_prefix
     ) :
         gadget<FieldT>(pb, annotation_prefix),
@@ -499,7 +417,7 @@ public:
         m_acc_result_precomp_gadget(pb, m_acc_result, m_acc_result_precomp, FMT(annotation_prefix, ".acc_precompute")),
         m_acc(pb,
               vkp.m_query[0],
-              {bits.bits.begin(), bits.bits.end()},
+              bits,
               FieldT::size_in_bits(),
               {vkp.m_query.begin() + 1, vkp.m_query.end()},
               m_acc_result,

--- a/libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp
@@ -395,9 +395,17 @@ public:
         }
     }
 
-    void generate_r1cs_constraints()
+    void generate_r1cs_constraints(bool enforce_bitness = true)
     {
-        // ... no constraints needed here
+        if( enforce_bitness )
+        {
+            int i = 0;
+            for( auto &bit_var : bits )
+            {
+                generate_boolean_r1cs_constraint<FieldT>(this->pb, bit_var, FMT(this->annotation_prefix, ".bitness[%d]", i));
+                i += 1;
+            }
+        }
     }
 
     void print(const char *prefix="") {

--- a/libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp
@@ -11,7 +11,7 @@ namespace libsnark {
 
 
 /**
-* Holds a Groth16 proof with its inputs
+* Holds a Groth16 proof (but not its inputs)
 * The A, B and C points are validated
 */
 template<typename ppT>

--- a/libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp
@@ -1,0 +1,460 @@
+#pragma once
+
+#include <libsnark/gadgetlib1/gadgets/basic_gadgets.hpp>
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_checks.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp>
+
+namespace libsnark {
+
+
+/**
+* Holds a Groth16 proof with its inputs
+* The A, B and C points are validated
+*/
+template<typename ppT>
+class gro16_proof_var : public gadget<libff::Fr<ppT> > {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+    typedef pb_variable<FieldT> FieldVarT;
+
+    G1VarT A;
+    G2VarT B;
+    G1VarT C;
+
+    // XXX: do we need a mode where we don't validate the proof points?
+    G1_checker_gadget<ppT> m_A_checker;
+    G2_checker_gadget<ppT> m_B_checker;
+    G1_checker_gadget<ppT> m_C_checker;
+
+    gro16_proof_var(
+        protoboard<FieldT> &pb,
+        const G1VarT &_A,
+        const G2VarT &_B,
+        const G1VarT &_C,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        A(_A),
+        B(_B),
+        C(_C),
+        m_A_checker(pb, A, FMT(annotation_prefix, ".A_checker")),
+        m_B_checker(pb, B, FMT(annotation_prefix, ".B_checker")),
+        m_C_checker(pb, C, FMT(annotation_prefix, ".C_checker"))
+    { }
+
+    gro16_proof_var(
+        protoboard<FieldT> &pb,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        A(pb, FMT(this->annotation_prefix, ".A")),
+        B(pb, FMT(this->annotation_prefix, ".B")),
+        C(pb, FMT(this->annotation_prefix, ".C")),
+        m_A_checker(pb, A, FMT(annotation_prefix, ".A_checker")),
+        m_B_checker(pb, B, FMT(annotation_prefix, ".B_checker")),
+        m_C_checker(pb, C, FMT(annotation_prefix, ".C_checker"))
+    {
+
+    }
+
+    void generate_r1cs_constraints()
+    {
+        m_A_checker.generate_r1cs_constraints();
+        m_B_checker.generate_r1cs_constraints();
+        m_C_checker.generate_r1cs_constraints();
+    }
+
+    /** Variables are already filled with values */
+    void generate_r1cs_witness()
+    {
+        m_A_checker.generate_r1cs_witness();
+        m_B_checker.generate_r1cs_witness();
+        m_C_checker.generate_r1cs_witness();
+    }
+
+    /** Fill variables from proof with inputs */
+    void generate_r1cs_witness(
+        const r1cs_gg_ppzksnark_proof<other_curve<ppT>> &proof
+    ) {
+        A.generate_r1cs_witness(proof.g_A);
+        B.generate_r1cs_witness(proof.g_B);
+        C.generate_r1cs_witness(proof.g_C);
+        generate_r1cs_witness();
+    }
+};
+
+
+/**
+* Holds a Groth16 verification key as variables
+* The points of the verification key are validated
+* This will be given to the preprocessor gadget
+*/
+template<typename ppT>
+class gro16_vk_var : public gadget<libff::Fr<ppT> > {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+
+    G1VarT m_alpha;
+    G2VarT m_beta;
+    G2VarT m_gamma;
+    G2VarT m_delta;
+
+    size_t n_inputs;
+    std::vector<G1VarT> m_IC;
+
+    std::vector<G1_checker_gadget<ppT>> m_g1_checkers;
+    std::vector<G2_checker_gadget<ppT>> m_g2_checkers;
+
+    void _init_checkers()
+    {
+        auto pb = this->pb;
+        const auto annotation_prefix = this->annotation_prefix;
+
+        m_g1_checkers.reserve(n_inputs + 1);
+        m_g1_checkers.emplace_back(pb, m_alpha, FMT(annotation_prefix, ".alpha_checker"));
+
+        m_g2_checkers.reserve(3);
+        m_g2_checkers.emplace_back(pb, m_beta, FMT(annotation_prefix, ".beta_checker"));
+        m_g2_checkers.emplace_back(pb, m_gamma, FMT(annotation_prefix, ".gamma_checker"));
+        m_g2_checkers.emplace_back(pb, m_delta, FMT(annotation_prefix, ".delta_checker"));
+
+        assert( n_inputs > 0 );
+        for( size_t i = 0; i < (n_inputs + 1); i++ )
+        {
+            m_IC.emplace_back(pb, FMT(annotation_prefix, ".input_%d", i));
+            m_g1_checkers.emplace_back(pb, m_IC.back(), FMT(annotation_prefix, ".IC_checker_%d", i));
+        }
+    }
+
+    /**
+    * Construct new variables to hold the verification key
+    * For when the verification key is a secret input
+    */
+    gro16_vk_var(
+        protoboard<FieldT> &pb,
+        size_t _n_inputs,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        m_alpha(pb, FMT(annotation_prefix, ".alpha")),
+        m_beta(pb, FMT(annotation_prefix, ".beta")),
+        m_gamma(pb, FMT(annotation_prefix, ".gamma")),
+        m_delta(pb, FMT(annotation_prefix, ".delta")),
+        n_inputs(_n_inputs)
+    {
+        _init_checkers();
+    }
+
+    /**
+    * Fill verification key from already existing variables
+    * When the verification key comes from somewhere else within the circuit
+    */
+    gro16_vk_var(
+        protoboard<FieldT> &pb,
+        const G1VarT &alpha,
+        const G2VarT &beta,
+        const G2VarT &gamma,
+        const G2VarT &delta,
+        const std::vector<G1VarT> &IC,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        m_alpha(alpha),
+        m_beta(beta),
+        m_gamma(gamma),
+        m_delta(delta),
+        n_inputs(IC.size())
+    {
+        _init_checkers();
+    }
+
+    void generate_r1cs_constraints()
+    {
+        for( auto &gadget : m_g1_checkers )
+            gadget.generate_r1cs_constraints();
+
+        for( auto &gadget : m_g2_checkers )
+            gadget.generate_r1cs_constraints();
+    }
+
+    /** When the VK variable values have already been filled */
+    void generate_r1cs_witness()
+    {
+        for( auto &gadget : m_g1_checkers )
+            gadget.generate_r1cs_constraints();
+
+        for( auto &gadget : m_g2_checkers )
+            gadget.generate_r1cs_constraints();
+    }
+
+    /** Fill variable values before witness of point checkers */
+    void generate_r1cs_witness(
+        const libff::G1<ppT> &alpha,
+        const libff::G2<ppT> &beta,
+        const libff::G2<ppT> &gamma,
+        const libff::G2<ppT> &delta,
+        const std::vector<libff::G1<ppT>> &IC
+    ) {
+        m_alpha.generate_r1cs_witness(alpha);
+        m_beta.generate_r1cs_witness(beta);
+        m_gamma.generate_r1cs_witness(gamma);
+        m_delta.generate_r1cs_witness(delta);
+
+        assert( m_IC.size() == IC.size() );
+        int i = 0;
+        for( const auto& x: IC )
+            m_IC[i++].generate_r1cs_witness(x);
+
+        generate_r1cs_witness();
+    }
+
+    template<typename T>
+    void generate_r1cs_witness(
+        const libsnark::r1cs_gg_ppzksnark_verification_key<T> &vk
+    ) {
+        m_alpha.generate_r1cs_witness(vk.alpha_g1);
+        m_beta.generate_r1cs_witness(vk.beta_g2);
+        m_gamma.generate_r1cs_witness(vk.gamma_g2);
+        m_delta.generate_r1cs_witness(vk.delta_g2);
+
+        m_IC[0].generate_r1cs_witness(vk.gamma_ABC_g1.first);
+        int i = 1;
+        for( const auto& x: vk.gamma_ABC_g1.rest.indices )
+            m_IC[i++].generate_r1cs_witness(vk.gamma_ABC_g1.rest.values[x]);
+
+        generate_r1cs_witness();
+    }
+};
+
+
+/**
+* Given the verification key variables
+* Pre-compute the miller loop coefficients
+* And the product of e(alpha,beta)
+* This becomes cheaper when used multiple times, to avoid computing coefficients again
+*/
+template<typename ppT>
+class gro16_vk_preprocessor {
+public:
+    typedef libff::Fr<ppT> FieldT;
+    typedef pb_variable<FieldT> FieldVarT;
+    typedef G1_precomputation<ppT> G1precompT;
+    typedef G2_precomputation<ppT> G2precompT;
+    typedef G1_variable<ppT> G1VarT;
+    typedef G2_variable<ppT> G2VarT;
+
+    G1precompT m_alpha;
+    precompute_G1_gadget<ppT> m_alpha_precomp;
+
+    G2precompT m_beta;
+    precompute_G2_gadget<ppT> m_beta_precomp;
+
+    G2precompT m_gamma;
+    precompute_G2_gadget<ppT> m_gamma_precomp;
+
+    G2precompT m_delta;
+    precompute_G2_gadget<ppT> m_delta_precomp;
+
+    Fqk_variable<ppT> m_alphabeta;
+    miller_loop_gadget<ppT> m_alphabeta_loop;
+
+    std::vector<G1VarT> m_IC_raw;
+
+    gro16_vk_preprocessor(
+        protoboard<FieldT> &pb,
+        const gro16_vk_var<ppT> &vk,
+        const std::string &annotation_prefix
+    ) :
+        // Precomputation gadget allocates the result variables
+        m_alpha_precomp(pb, vk.m_alpha, m_alpha, FMT(annotation_prefix, ".alpha_precomp")),
+        m_beta_precomp(pb, vk.m_beta, m_beta, FMT(annotation_prefix, ".beta_precomp")),
+        m_gamma_precomp(pb, vk.m_gamma, m_gamma, FMT(annotation_prefix, ".gamma_precomp")),
+        m_delta_precomp(pb, vk.m_delta, m_delta, FMT(annotation_prefix, ".delta_precomp")),
+        // Miller loop to precompute e(alpha,beta)
+        m_alphabeta(pb, FMT(annotation_prefix, ".alphabeta")),
+        m_alphabeta_loop(pb, m_alpha, m_beta, m_alphabeta, FMT(annotation_prefix, ".alphabeta_miller_loop")),
+        // Input commitment
+        m_IC_raw(vk.m_IC)
+    {
+    }
+
+    void generate_r1cs_constraints()
+    {
+        m_alpha_precomp.generate_r1cs_constraints();
+        m_beta_precomp.generate_r1cs_constraints();
+        m_gamma_precomp.generate_r1cs_constraints();
+        m_delta_precomp.generate_r1cs_constraints();
+
+        m_alphabeta_loop.generate_r1cs_constraints();
+    }
+
+    void generate_r1cs_witness() 
+    {
+        m_alpha_precomp.generate_r1cs_witness();
+        m_beta_precomp.generate_r1cs_witness();
+        m_gamma_precomp.generate_r1cs_witness();
+        m_delta_precomp.generate_r1cs_witness();
+
+        m_alphabeta_loop.generate_r1cs_witness();
+    }
+};
+
+
+/**
+* Holds the input bits
+*/
+template<typename ppT>
+class gro16_inputbits_gadget : public gadget<libff::Fr<ppT>>
+{
+public:
+    typedef libff::Fr<ppT> FieldT;
+
+    const size_t inputs_count;
+    pb_variable_array<FieldT> bits; // Contiguous array of bits
+
+    gro16_inputbits_gadget(
+        protoboard<FieldT> &pb,
+        const size_t n_inputs,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        inputs_count(n_inputs)
+    {
+        assert( inputs_count > 0 );
+        const size_t n_input_bits = FieldT::size_in_bits() * inputs_count;
+        bits.allocate(pb, n_input_bits, FMT(annotation_prefix, ".bits"));
+    }
+
+    gro16_inputbits_gadget(
+        protoboard<FieldT> &pb,
+        pb_variable_array<FieldT> bits,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        inputs_count(bits.size() / FieldT::size_in_bits()),
+        bits(bits)
+    {
+        assert( inputs_count > 0 );
+        assert( (bits.size() % FieldT::size_in_bits()) == 0 );
+    }
+
+    void generate_r1cs_witness()
+    {
+        // ... nothing to do
+        // ... variables have been passed in via constructor
+        // ... values are assumed to have been populated elsewhere
+    }
+
+    /** Fill input bits from field elements */
+    template<typename T>
+    void generate_r1cs_witness(const std::vector<T> inputs)
+    {
+        assert( inputs_count == inputs.size() );
+
+        int i = 0;
+
+        for (const auto &el : inputs)
+        {
+            const auto el_bits = libff::convert_field_element_to_bit_vector(el, T::size_in_bits());
+
+            for( const auto b : el_bits )
+                this->pb.val(bits[i++]) = (b ? 1 : 0);
+        }
+    }
+
+    void generate_r1cs_constraints()
+    {
+        // ... no constraints needed here
+    }
+};
+
+
+
+template<typename ppT>
+class gro16_verifier_gadget : public gadget<libff::Fr<ppT>> {
+public:
+    typedef G1_precomputation<ppT> G1precompT;
+    typedef G2_precomputation<ppT> G2precompT;
+    typedef libff::Fr<ppT> FieldT;
+
+    G1precompT m_A;
+    precompute_G1_gadget<ppT> m_A_precomp;
+
+    G2precompT m_B;
+    precompute_G2_gadget<ppT> m_B_precomp;
+
+    G1precompT m_C;
+    precompute_G1_gadget<ppT> m_C_precomp;
+
+    const G1_variable<ppT> m_acc_result;
+    G1precompT m_acc_result_precomp;
+    precompute_G1_gadget<ppT> m_acc_result_precomp_gadget;
+
+    G1_multiscalar_mul_gadget<ppT> m_acc;
+
+    pairing_product_gadget<ppT> m_ppg;
+    // TODO: calculate input commitment...
+
+    gro16_verifier_gadget(
+        protoboard<FieldT> &pb,
+        const gro16_proof_var<ppT> &proof,
+        const gro16_vk_preprocessor<ppT> &vkp,
+        const gro16_inputbits_gadget<ppT> &bits,
+        const std::string &annotation_prefix
+    ) :
+        gadget<FieldT>(pb, annotation_prefix),
+        m_A_precomp(pb, proof.A, m_A, FMT(annotation_prefix, ".A_precompute")),
+        m_B_precomp(pb, proof.B, m_B, FMT(annotation_prefix, ".B_precompute")),
+        m_C_precomp(pb, proof.C, m_C, FMT(annotation_prefix, ".C_precompute")),
+        m_acc_result(pb, ".acc"),
+        m_acc_result_precomp_gadget(pb, m_acc_result, m_acc_result_precomp, FMT(annotation_prefix, ".C_precompute")),
+        m_acc(pb,
+              *vkp.m_IC_raw.begin(),
+              {bits.bits.begin(), bits.bits.end()},
+              FieldT::size_in_bits(),
+              {vkp.m_IC_raw.begin() + 1, vkp.m_IC_raw.end()},    // slice IC[1:]
+              m_acc_result,
+              FMT(annotation_prefix, ".acc_gadget")),
+        m_ppg(pb,
+              {
+                pairing_input_pair<ppT>(m_A, m_B),
+                pairing_input_pair<ppT>(m_acc_result_precomp, vkp.m_gamma),
+                pairing_input_pair<ppT>(m_C, vkp.m_delta)
+              },
+              {vkp.m_alphabeta},
+              FMT(annotation_prefix, ".pairing_product"))
+    {
+        // ... nothing more to do here
+    }
+
+    void generate_r1cs_witness()
+    {
+        m_A_precomp.generate_r1cs_witness();
+        m_B_precomp.generate_r1cs_witness();
+        m_C_precomp.generate_r1cs_witness();
+        m_acc.generate_r1cs_witness();
+        m_acc_result_precomp_gadget.generate_r1cs_witness();
+        m_ppg.generate_r1cs_witness();
+    }
+
+    void generate_r1cs_constraints()
+    {
+        m_A_precomp.generate_r1cs_constraints();
+        m_B_precomp.generate_r1cs_constraints();
+        m_C_precomp.generate_r1cs_constraints();
+        m_acc.generate_r1cs_constraints();
+        m_acc_result_precomp_gadget.generate_r1cs_constraints();
+        m_ppg.generate_r1cs_constraints();
+    }
+};
+
+
+} // libsnark
+

--- a/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
@@ -512,7 +512,7 @@ int main(void)
     libff::start_profiling();
     libff::mnt4_pp::init_public_params();
     libff::mnt6_pp::init_public_params();
-    /*
+
     test_mul<libff::mnt4_Fq2, Fp2_variable, Fp2_mul_gadget>("mnt4_Fp2");
     test_sqr<libff::mnt4_Fq2, Fp2_variable, Fp2_sqr_gadget>("mnt4_Fp2");
 
@@ -563,7 +563,7 @@ int main(void)
 
     test_pairing_product_gadget<libff::mnt4_pp>("mnt4");
     test_pairing_product_gadget<libff::mnt6_pp>("mnt6");
-    */
+
     test_gro16_verifier<libff::mnt4_pp, libff::mnt6_pp>("mnt4", "mnt6");
     test_gro16_verifier<libff::mnt6_pp, libff::mnt4_pp>("mnt6", "mnt4");
 }

--- a/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
@@ -260,7 +260,7 @@ void test_gm17_verifier(const std::string &annotation_A, const std::string &anno
     gm17_proof_var<ppT_B> proof(pb, "proof");
     gm17_vk_var<ppT_B> vk(pb, primary_input_size, "vk");
     gm17_vk_preprocessor<ppT_B> vkp(pb, vk, "vkp");
-    gm17_verifier_gadget<ppT_B> verifier(pb, proof, vk, vkp, input_as_bits, "verifier");
+    gm17_verifier_gadget<ppT_B> verifier(pb, proof, vkp, input_as_bits, "verifier");
 
     // Generate constraints, displaying breakdown per function
     PROFILE_CONSTRAINTS(pb, "convert 3 input to bits") {

--- a/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
@@ -579,7 +579,11 @@ int main(void)
     libff::mnt4_pp::init_public_params();
     libff::mnt6_pp::init_public_params();
 
-    /*
+    test_G2_add_gadget_const<libff::mnt4_pp>("mnt4");
+    test_G2_add_gadget_const<libff::mnt6_pp>("mnt6");
+
+    test_G2_add_gadget_var<libff::mnt4_pp>("mnt4");
+    test_G2_add_gadget_var<libff::mnt6_pp>("mnt6");
 
     test_mul<libff::mnt4_Fq2, Fp2_variable, Fp2_mul_gadget>("mnt4_Fp2");
     test_sqr<libff::mnt4_Fq2, Fp2_variable, Fp2_sqr_gadget>("mnt4_Fp2");
@@ -634,7 +638,6 @@ int main(void)
 
     test_gro16_verifier<libff::mnt4_pp, libff::mnt6_pp>("mnt4", "mnt6");
     test_gro16_verifier<libff::mnt6_pp, libff::mnt4_pp>("mnt6", "mnt4");
-    */
 
     test_gm17_verifier<libff::mnt4_pp, libff::mnt6_pp>("mnt4", "mnt6");
     test_gm17_verifier<libff::mnt6_pp, libff::mnt4_pp>("mnt6", "mnt4");

--- a/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
@@ -14,6 +14,7 @@
 #include <libsnark/gadgetlib1/gadgets/fields/fp6_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp>
 #include <libsnark/gadgetlib1/gadgets/verifiers/gro16.hpp>
+#include <libsnark/gadgetlib1/gadgets/verifiers/gm17.hpp>
 #include <libsnark/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp>
 #include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>
 #include <libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp>
@@ -195,6 +196,71 @@ void test_gro16_verifier(const std::string &annotation_A, const std::string &ann
     gro16_vk_var<ppT_B> vk(pb, primary_input_size, "vk");
     gro16_vk_preprocessor<ppT_B> vkp(pb, vk, "vkp");
     gro16_verifier_gadget<ppT_B> verifier(pb, proof, vkp, input_as_bits, "verifier");
+
+    // Generate constraints, displaying breakdown per function
+    PROFILE_CONSTRAINTS(pb, "convert 3 input to bits") {
+        input_as_bits.generate_r1cs_constraints();
+    }
+    PROFILE_CONSTRAINTS(pb, "validate proof") {
+        proof.generate_r1cs_constraints();
+    }
+    PROFILE_CONSTRAINTS(pb, "validate verification key") {
+        vk.generate_r1cs_constraints();
+    }
+    PROFILE_CONSTRAINTS(pb, "verification key constraints") {
+        vkp.generate_r1cs_constraints();
+    }
+    PROFILE_CONSTRAINTS(pb, "proof verifier constraints") {
+        verifier.generate_r1cs_constraints();
+    }
+
+    // Create witness
+    input_as_bits.generate_r1cs_witness(example.primary_input);
+    proof.generate_r1cs_witness(pi);
+    vk.generate_r1cs_witness(keypair.vk);
+    vkp.generate_r1cs_witness();
+    verifier.generate_r1cs_witness();
+
+    printf("positive test:\n");
+    assert(pb.is_satisfied());
+
+    pb.val(input_as_bits.bits[0]) = FieldT_B::one() - pb.val(input_as_bits.bits[0]);
+    verifier.generate_r1cs_witness();
+    printf("negative test:\n");
+    assert(!pb.is_satisfied());
+
+    PRINT_CONSTRAINT_PROFILING();
+    printf("number of constraints for verifier: %zu (verifier is implemented in %s constraints and verifies %s proofs))\n",
+           pb.num_constraints(), annotation_B.c_str(), annotation_A.c_str());
+}
+
+
+template<typename ppT_A, typename ppT_B>
+void test_gm17_verifier(const std::string &annotation_A, const std::string &annotation_B)
+{
+    typedef libff::Fr<ppT_A> FieldT_A;
+    typedef libff::Fr<ppT_B> FieldT_B;
+
+    // Example constaint system
+    const size_t num_constraints = 50;
+    const size_t primary_input_size = 3;
+    auto example = generate_r1cs_example_with_field_input<FieldT_A>(num_constraints, primary_input_size);
+    assert(example.primary_input.size() == primary_input_size);
+    assert(example.constraint_system.is_satisfied(example.primary_input, example.auxiliary_input));
+
+    // Create keypair and proof for constraints
+    auto keypair = r1cs_se_ppzksnark_generator<ppT_A>(example.constraint_system);
+    auto pi = r1cs_se_ppzksnark_prover<ppT_A>(keypair.pk, example.primary_input, example.auxiliary_input);
+    bool bit = r1cs_se_ppzksnark_verifier_strong_IC<ppT_A>(keypair.vk, example.primary_input, pi);
+    assert(bit);
+
+    protoboard<FieldT_B> pb;
+    // Create gadgets to verify
+    gm17_inputbits_gadget<ppT_B> input_as_bits(pb, primary_input_size, "input_bits");
+    gm17_proof_var<ppT_B> proof(pb, "proof");
+    gm17_vk_var<ppT_B> vk(pb, primary_input_size, "vk");
+    gm17_vk_preprocessor<ppT_B> vkp(pb, vk, "vkp");
+    gm17_verifier_gadget<ppT_B> verifier(pb, proof, vk, vkp, input_as_bits, "verifier");
 
     // Generate constraints, displaying breakdown per function
     PROFILE_CONSTRAINTS(pb, "convert 3 input to bits") {
@@ -513,6 +579,8 @@ int main(void)
     libff::mnt4_pp::init_public_params();
     libff::mnt6_pp::init_public_params();
 
+    /*
+
     test_mul<libff::mnt4_Fq2, Fp2_variable, Fp2_mul_gadget>("mnt4_Fp2");
     test_sqr<libff::mnt4_Fq2, Fp2_variable, Fp2_sqr_gadget>("mnt4_Fp2");
 
@@ -566,4 +634,8 @@ int main(void)
 
     test_gro16_verifier<libff::mnt4_pp, libff::mnt6_pp>("mnt4", "mnt6");
     test_gro16_verifier<libff::mnt6_pp, libff::mnt4_pp>("mnt6", "mnt4");
+    */
+
+    test_gm17_verifier<libff::mnt4_pp, libff::mnt6_pp>("mnt4", "mnt6");
+    test_gm17_verifier<libff::mnt6_pp, libff::mnt4_pp>("mnt6", "mnt4");
 }

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
@@ -167,6 +167,8 @@ std::istream& operator>>(std::istream &in, r1cs_gg_ppzksnark_verification_key<pp
 template<typename ppT>
 class r1cs_gg_ppzksnark_verification_key {
 public:
+    libff::G1<ppT> alpha_g1;
+    libff::G2<ppT> beta_g2;
     libff::GT<ppT> alpha_g1_beta_g2;
     libff::G2<ppT> gamma_g2;
     libff::G2<ppT> delta_g2;
@@ -174,11 +176,14 @@ public:
     accumulation_vector<libff::G1<ppT> > gamma_ABC_g1;
 
     r1cs_gg_ppzksnark_verification_key() = default;
-    r1cs_gg_ppzksnark_verification_key(const libff::GT<ppT> &alpha_g1_beta_g2,
+    r1cs_gg_ppzksnark_verification_key(const libff::G1<ppT> &alpha_g1,
+                                       const libff::G2<ppT> &beta_g2,
                                        const libff::G2<ppT> &gamma_g2,
                                        const libff::G2<ppT> &delta_g2,
                                        const accumulation_vector<libff::G1<ppT> > &gamma_ABC_g1) :
-        alpha_g1_beta_g2(alpha_g1_beta_g2),
+        alpha_g1(alpha_g1),
+        beta_g2(beta_g2),
+        alpha_g1_beta_g2(ppT::reduced_pairing(alpha_g1, beta_g2)),
         gamma_g2(gamma_g2),
         delta_g2(delta_g2),
         gamma_ABC_g1(gamma_ABC_g1)

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
@@ -210,6 +210,12 @@ public:
         return (gamma_ABC_g1.size_in_bits() + 2 * libff::G2<ppT>::size_in_bits());
     }
 
+    size_t num_inputs() const
+    {
+        return gamma_ABC_g1.rest.size();
+    }
+
+
     void print_size() const
     {
         libff::print_indent(); printf("* G1 elements in VK: %zu\n", this->G1_size());

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -352,8 +352,8 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
     libff::leave_block("Generate R1CS proving key");
 
     libff::enter_block("Generate R1CS verification key");
-    libff::GT<ppT> alpha_g1_beta_g2 = ppT::reduced_pairing(alpha_g1, beta_g2);
-    libff::G2<ppT> gamma_g2 = gamma * G2_gen;
+    //libff::GT<ppT> alpha_g1_beta_g2 = ppT::reduced_pairing(alpha_g1, beta_g2);
+    const libff::G2<ppT> gamma_g2 = gamma * G2_gen;
 
     libff::enter_block("Encode gamma_ABC for R1CS verification key");
     libff::G1<ppT> gamma_ABC_g1_0 = gamma_ABC_0 * g1_generator;
@@ -363,23 +363,25 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
 
     libff::leave_block("Call to r1cs_gg_ppzksnark_generator");
 
-    accumulation_vector<libff::G1<ppT> > gamma_ABC_g1(std::move(gamma_ABC_g1_0), std::move(gamma_ABC_g1_values));
+    const accumulation_vector<libff::G1<ppT> > gamma_ABC_g1(std::move(gamma_ABC_g1_0), std::move(gamma_ABC_g1_values));
 
-    r1cs_gg_ppzksnark_verification_key<ppT> vk = r1cs_gg_ppzksnark_verification_key<ppT>(alpha_g1_beta_g2,
-                                                                                         gamma_g2,
-                                                                                         delta_g2,
-                                                                                         gamma_ABC_g1);
+    auto vk = r1cs_gg_ppzksnark_verification_key<ppT>(
+        alpha_g1,
+        beta_g2,
+        gamma_g2,
+        delta_g2,
+        gamma_ABC_g1);
 
-    r1cs_gg_ppzksnark_proving_key<ppT> pk = r1cs_gg_ppzksnark_proving_key<ppT>(std::move(alpha_g1),
-                                                                               std::move(beta_g1),
-                                                                               std::move(beta_g2),
-                                                                               std::move(delta_g1),
-                                                                               std::move(delta_g2),
-                                                                               std::move(A_query),
-                                                                               std::move(B_query),
-                                                                               std::move(H_query),
-                                                                               std::move(L_query),
-                                                                               std::move(r1cs_copy));
+    auto pk = r1cs_gg_ppzksnark_proving_key<ppT>(std::move(alpha_g1),
+                                                 std::move(beta_g1),
+                                                 std::move(beta_g2),
+                                                 std::move(delta_g1),
+                                                 std::move(delta_g2),
+                                                 std::move(A_query),
+                                                 std::move(B_query),
+                                                 std::move(H_query),
+                                                 std::move(L_query),
+                                                 std::move(r1cs_copy));
 
     pk.print_size();
     vk.print_size();

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp
@@ -223,6 +223,11 @@ public:
         return 3;
     }
 
+    size_t num_inputs() const
+    {
+        return query.size() - 1;
+    }
+
     size_t size_in_bits() const
     {
         return (G1_size() * libff::G1<ppT>::size_in_bits() +


### PR DESCRIPTION
Fixes: #2 
Fixes: #4

This implements the GM17 verifier and G2 point addition gadgets, with support for mnt[46]753

It is a branch off of #1 

Constraints, mnt4, verifies mnt6:

* Number of constraints in [convert 3 input to bits]: 894
* Number of constraints in [validate proof]: 21
* Number of constraints in [validate verification key]: 63
* Number of constraints in [verification key constraints]: 19372
* Number of constraints in [proof verifier constraints]: 58029
number of constraints for verifier: 78379 (verifier is implemented in mnt4 constraints and verifies mnt6 proofs))

Constraints, mnt6 verifies mnt4:

 * Number of constraints in [convert 3 input to bits]: 894
* Number of constraints in [validate proof]: 13
* Number of constraints in [validate verification key]: 39
* Number of constraints in [verification key constraints]: 10024
* Number of constraints in [proof verifier constraints]: 34069
number of constraints for verifier: 45039 (verifier is implemented in mnt6 constraints and verifies mnt4 proofs))
